### PR TITLE
changes to activer_user_header

### DIFF
--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -140,7 +140,7 @@ module NotionAPI
       # ! retrieves all info pertaining to a block Id.
       # ! clean_id -> the block ID or URL cleaned : ``str``
       Core.options['cookies'][:token_v2] = @@token_v2
-      Core.options['headers']['x-notion-active-user-header'] = @active_user_header
+      Core.options['headers']['x-notion-active-user-header'] = @@active_user_header
       cookies = Core.options['cookies']
       headers = Core.options['headers']
 


### PR DESCRIPTION
`active_user_header` is now stated as a class variable in get_all_block_info.