### PR TITLE
fix situations where no previous select options exist

### DIFF
--- a/lib/notion_api/notion_types/collection_view_blocks.rb
+++ b/lib/notion_api/notion_types/collection_view_blocks.rb
@@ -61,7 +61,7 @@ module NotionAPI
       data.keys.each_with_index do |col_name, j|
         unless col_map.keys.include?(col_name.to_s); raise ArgumentError, "Column '#{col_name.to_s}' does not exist." end
         if %q[select multi_select].include?(schema[col_map[col_name.to_s]]["type"])
-          options = schema[col_map[col_name.to_s]]["options"].map {|option| option["value"]}
+          options = schema[col_map[col_name.to_s]]["options"].nil? ? [] : schema[col_map[col_name.to_s]]["options"].map {|option| option["value"]}
           if !options.include?(data[col_name])
             create_new_option = Utils::CollectionViewComponents.add_new_option(col_map[col_name.to_s], data[col_name], @collection_id)
             operations.push(create_new_option)

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -491,6 +491,8 @@ module Utils
     end
 
     def self.add_new_option(column, value, collection_id)
+      colors = ["default", "gray", "brown", "orange", "yellow", "green", "blue", "purple", "pink", "red"]
+      random_color = colors[rand(0...colors.length)]
       table = "collection"
       path = ["schema", column, "options"]
       command = "keyedObjectListAfter"
@@ -498,7 +500,7 @@ module Utils
         "value": {
             "id": SecureRandom.hex(16),
             "value": value,
-            "color": "green"
+            "color": random_color
         }
       }
 

--- a/lib/notion_api/version.rb
+++ b/lib/notion_api/version.rb
@@ -1,3 +1,3 @@
 module NotionAPI
-    VERSION = '1.0.7'
+    VERSION = '1.1.0'
 end


### PR DESCRIPTION
If no options previously exist for a **select** or **multi-select** property, it used to throw an error. Now, it does not