### PR TITLE
Better Parsing for Property Names

### DIFF
--- a/lib/notion_api/version.rb
+++ b/lib/notion_api/version.rb
@@ -1,3 +1,3 @@
 module NotionAPI
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
 end

--- a/spec/blocks_spec.rb
+++ b/spec/blocks_spec.rb
@@ -146,5 +146,16 @@ describe NotionAPI::BlockTemplate do
       end
     end
   end
+  context "cleaning the property names of a Notion Collection View." do
+    it "FULL_PAGE: should parse the column name, replace non-alphanumeric characters, and then return the cleaned column name" do
+      test_prop_hash = {"1234"=> "Col Name (one) (two) 1234?!>"}
+      expect($Full_page_cv.clean_property_names(test_prop_hash, "1234")).to eq(:col_name_one_two_1234)
+    end
+    it "INLINE: should parse the column name, replace non-alphanumeric characters, and thenr eturn the cleaned column name" do 
+      inline_cv = $Block_spec_page.get_collection("3224c94f-e660-4092-9dba-d26b69b68d40")
+      test_prop_hash = {"1234"=> "Col Name (#$^&^^*one) (@!#$!two) 1!@#2$%@3!@#@?4!>"}
+      expect(inline_cv.clean_property_names(test_prop_hash, "1234")).to eq(:col_name_one_two_1234)
+    end
+  end
 end
 

--- a/spec/spec_variables.rb
+++ b/spec/spec_variables.rb
@@ -54,5 +54,7 @@ module Helpers
     $Block_spec_get_collection_id = "3224c94f-e660-4092-9dba-d26b69b68d40"
     $Block_spec_add_row_id = "eaa144ab-d91b-4640-b13a-a0ba1c8dd450"
     $Vehicle_data_csv = File.read("./spec/fixtures/vauto_inventory.csv")
+    $Full_page_cv_url = "https://www.notion.so/danmurphy/3a8c0397841748b08da76f188b7fb381?v=a68811a8c18b433b9787b17dcd83527e"
+    $Full_page_cv = $Client.get_page($Full_page_cv_url)
     $Json = JSON.parse(File.read("./spec/fixtures/emoji_data.json"))
 end


### PR DESCRIPTION
Property Names can now contain non-alphanumeric characters. They are parsed out using `[a-z0-9]` RegEx