### PR TITLE
Updates to create method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    notion_api (1.0.0)
-      httparty
-      json
+    notion (1.1.3)
+      httparty (~> 0.17)
+      json (~> 2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +13,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (2.3.1)
+    json (2.5.1)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
@@ -25,19 +25,19 @@ GEM
     rake (13.0.1)
     regexp_parser (1.8.2)
     rexml (3.2.4)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.0)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.3)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.4)
     rubocop (1.4.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -50,7 +50,6 @@ GEM
     rubocop-ast (1.1.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
-    rufo (0.12.0)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -58,11 +57,10 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  notion_api!
-  rake
-  rspec
-  rubocop
-  rufo
+  notion!
+  rake (~> 13.0.0)
+  rspec (~> 3.9.0)
+  rubocop (~> 1.4.0)
 
 BUNDLED WITH
    2.1.4

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -20,4 +20,4 @@ end
 @client = NotionAPI::Client.new(ENV['token_v2'])
 
 @page = @client.get_page("https://www.notion.so/danmurphy/tutorials-69d5c69d287f402c9ea28934f890adc1")
-@page.create(NotionAPI::ImageBlock, "Title", options: {"url" => "HI"})
+@page.create(NotionAPI::ImageBlock, "Title", options: {url: "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb"})

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -20,5 +20,5 @@ end
 @client = NotionAPI::Client.new(ENV['token_v2'])
 
 @page = @client.get_page("https://www.notion.so/danmurphy/tutorials-69d5c69d287f402c9ea28934f890adc1")
-@page.create(NotionAPI::ImageBlock, "Title", options: {url: "/Users/danielmurphy/Desktop/Screen Shot 2020-10-19 at 12.06.01 PM.png"})
+@page.create(NotionAPI::ImageBlock, "Title", options: {image: "/Users/danielmurphy/Downloads/logo512.png"})
 # @page.create(NotionAPI::ImageBlock, "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb")

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -15,3 +15,9 @@ module NotionAPI
     end
   end
 end
+
+
+@client = NotionAPI::Client.new(ENV['token_v2'])
+
+@page = @client.get_page("https://www.notion.so/danmurphy/tutorials-69d5c69d287f402c9ea28934f890adc1")
+@page.create(NotionAPI::ImageBlock, "Title", options: {"url" => "HI"})

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -20,4 +20,5 @@ end
 @client = NotionAPI::Client.new(ENV['token_v2'])
 
 @page = @client.get_page("https://www.notion.so/danmurphy/tutorials-69d5c69d287f402c9ea28934f890adc1")
-@page.create(NotionAPI::ImageBlock, "Title", options: {url: "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb"})
+@page.create(NotionAPI::ImageBlock, "Title", options: {url: "/Users/danielmurphy/Desktop/Screen Shot 2020-10-19 at 12.06.01 PM.png"})
+# @page.create(NotionAPI::ImageBlock, "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb")

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -15,11 +15,3 @@ module NotionAPI
     end
   end
 end
-
-@client = NotionAPI::Client.new(ENV["token_v2"])
-@page = @client.get_page("https://www.notion.so/danmurphy/d9d49ca64a2a4911ad6dffe898a468e5?v=28d7c1ea5fe347d8ae002eee11e10888")
-p @page
-# @block = @page.create(NotionAPI::TextBlock, "Title")
-# @block.title="NEW"
-# @img = @page.create(NotionAPI::ImageBlock, "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb", options: { image: "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb" })
-# p @img.title

--- a/lib/notion_api/client.rb
+++ b/lib/notion_api/client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'core'
-require_relative 'blocks'
+require_relative "core"
+require_relative "blocks"
 
 module NotionAPI
   # acts as the 'main interface' to the methods of this package.
@@ -16,9 +16,10 @@ module NotionAPI
   end
 end
 
-
-@client = NotionAPI::Client.new(ENV['token_v2'])
-
-@page = @client.get_page("https://www.notion.so/danmurphy/tutorials-69d5c69d287f402c9ea28934f890adc1")
-@page.create(NotionAPI::ImageBlock, "Title", options: {image: "/Users/danielmurphy/Downloads/logo512.png"})
-# @page.create(NotionAPI::ImageBlock, "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb")
+@client = NotionAPI::Client.new(ENV["token_v2"])
+@page = @client.get_page("https://www.notion.so/danmurphy/d9d49ca64a2a4911ad6dffe898a468e5?v=28d7c1ea5fe347d8ae002eee11e10888")
+p @page
+# @block = @page.create(NotionAPI::TextBlock, "Title")
+# @block.title="NEW"
+# @img = @page.create(NotionAPI::ImageBlock, "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb", options: { image: "https://images.unsplash.com/photo-1467348733814-f93fc480bec6?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb" })
+# p @img.title

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -310,7 +310,11 @@ module NotionAPI
       PageBlock.new(clean_id, block_title, block_parent_id)
     end
 
-    def retrieve_collection_view_page_information(**kwargs)
+    def retrieve_collection_view_page_information(page_meta = {})
+      clean_id = page_meta.fetch(:clean_id)
+      jsonified_record_response = page_meta.fetch(:jsonified_record_response)
+      block_parent_id = page_meta.fetch(:parent_id)
+
       collection_id = extract_collection_id(clean_id, jsonified_record_response)
       block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
       view_id = extract_view_ids(clean_id, jsonified_record_response)[0]

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -46,24 +46,7 @@ module NotionAPI
 
       raise ArgumentError, "the URL or ID passed to the get_page method must be that of a Page Block." if !["collection_view_page", "page"].include?(block_type)
 
-      instantiated_instance(block_type, clean_id, block_parent_id, jsonified_record_response)
-
-      # if block_type == "page"
-      #   block_title = extract_title(clean_id, jsonified_record_response)
-      #   PageBlock.new(clean_id, block_title, block_parent_id)
-      # elsif block_type == "collection_view_page"
-      #   collection_id = extract_collection_id(clean_id, jsonified_record_response)
-      #   block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
-      #   view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
-      #   schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
-      #   column_mappings = schema.keys
-      #   column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
-
-      #   collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
-      #   collection_view_page.instance_variable_set(:@column_names, column_names)
-      #   CollectionView.class_eval { attr_reader :column_names }
-      #   collection_view_page
-      # end
+      get_instantiated_instance_for(block_type, clean_id, block_parent_id, jsonified_record_response)
     end
 
     def children(url_or_id = @id)
@@ -333,7 +316,7 @@ module NotionAPI
       collection_view_page
     end
 
-    def instantiated_instance(block_type, clean_id, parent_id, jsonified_record_response)
+    def get_instantiated_instance_for(block_type, clean_id, parent_id, jsonified_record_response)
       case block_type
       when "page" then extract_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
       when "collection_view_page" then extract_collection_view_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -139,8 +139,7 @@ module NotionAPI
         return get_all_block_info(body, i)
       else
         if i == 10 && response_invalid
-          raise InvalidClientInstantiationError, "Attempted to retrieve block 10 times and received an empty response each time. \
-          Please make sure you have a valid token_v2 value set. If you do, then try setting the 'active_user_header' variable as well."
+          raise InvalidClientInstantiationError, "Attempted to retrieve block 10 times and received an empty response each time. Please make sure you have a valid token_v2 value set. If you do, then try setting the 'active_user_header' variable as well."
         else
           return jsonified_record_response
         end
@@ -317,7 +316,7 @@ module NotionAPI
     end
 
     class InvalidClientInstantiationError < StandardError
-      def initialize(msg = "Custom exception that is raised when an invalid property type is passed as a mapping.", exception_type = "schema_type")
+      def initialize(msg = "Custom exception that is raised when an invalid property type is passed as a mapping.", exception_type = "instantiation_type")
         @exception_type = exception_type
         super(msg)
       end

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -17,8 +17,8 @@ module NotionAPI
     attr_reader :clean_id, :cookies, :headers
 
     def initialize(token_v2, active_user_header)
-      @@token_v2 = token_v2
-      @@active_user_header = active_user_header
+      @token_v2 = token_v2
+      @active_user_header = active_user_header
     end
 
     def get_page(url_or_id)
@@ -41,7 +41,6 @@ module NotionAPI
         i += 1
       end
 
-      block_id = clean_id
       block_type = extract_type(clean_id, jsonified_record_response)
       block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
 
@@ -49,16 +48,16 @@ module NotionAPI
 
       if block_type == "page"
         block_title = extract_title(clean_id, jsonified_record_response)
-        PageBlock.new(block_id, block_title, block_parent_id)
+        PageBlock.new(clean_id, block_title, block_parent_id)
       elsif block_type == "collection_view_page"
-        collection_id = extract_collection_id(block_id, jsonified_record_response)
+        collection_id = extract_collection_id(clean_id, jsonified_record_response)
         block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
-        view_id = extract_view_ids(block_id, jsonified_record_response)[0]
+        view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
         schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
         column_mappings = schema.keys
         column_names = column_mappings.map { |mapping| schema[mapping]['name']}
 
-        collection_view_page = CollectionViewPage.new(block_id, block_title, block_parent_id, collection_id, view_id)
+        collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
         collection_view_page.instance_variable_set(:@column_names, column_names)
         CollectionView.class_eval{attr_reader :column_names}
         collection_view_page
@@ -106,8 +105,8 @@ module NotionAPI
     def get_notion_id(body)
       # ! retrieves a users ID from the headers of a Notion response object.
       # ! body -> the body to send in the request : ``Hash``
-      Core.options['cookies'][:token_v2] = @@token_v2
-      Core.options['headers']['x-notion-active-user-header'] = @@active_user_header
+      Core.options['cookies'][:token_v2] = @token_v2
+      Core.options['headers']['x-notion-active-user-header'] = @active_user_header
       cookies = Core.options['cookies']
       headers = Core.options['headers']
       request_url = URLS[:GET_BLOCK]
@@ -153,8 +152,8 @@ module NotionAPI
     def get_all_block_info(_clean_id, body)
       # ! retrieves all info pertaining to a block Id.
       # ! clean_id -> the block ID or URL cleaned : ``str``
-      Core.options['cookies'][:token_v2] = @@token_v2
-      Core.options['headers']['x-notion-active-user-header'] = @@active_user_header
+      Core.options['cookies'][:token_v2] = @token_v2
+      Core.options['headers']['x-notion-active-user-header'] = @active_user_header
       cookies = Core.options['cookies']
       headers = Core.options['headers']
 

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -68,6 +68,7 @@ module NotionAPI
       }
       jsonified_record_response = get_all_block_info(request_body)
 
+      # if no content, returns empty list
       jsonified_record_response["block"][clean_id]["value"]["content"] || []
     end
 
@@ -105,7 +106,7 @@ module NotionAPI
         verticalColumns: false,
       }
       jsonified_record_response = get_all_block_info(request_body)
-      
+
       properties = jsonified_record_response["block"][clean_id]["value"]["properties"]
       formats = jsonified_record_response["block"][clean_id]["value"]["format"]
       return {
@@ -114,7 +115,7 @@ module NotionAPI
              }
     end
 
-    def get_all_block_info(body, i=0)
+    def get_all_block_info(body, i = 0)
       # ! retrieves all info pertaining to a block Id.
       # ! clean_id -> the block ID or URL cleaned : ``str``
       Core.options["cookies"][:token_v2] = @@token_v2
@@ -132,8 +133,8 @@ module NotionAPI
 
       jsonified_record_response = JSON.parse(response.body)["recordMap"]
       response_invalid = (!jsonified_record_response || jsonified_record_response.empty? || jsonified_record_response["block"].empty?)
-      
-      if i <10 && response_invalid
+
+      if i < 10 && response_invalid
         i = i + 1
         return get_all_block_info(body, i)
       else
@@ -143,7 +144,6 @@ module NotionAPI
         else
           return jsonified_record_response
         end
-
       end
     end
 

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require_relative 'utils'
-require 'httparty'
+require_relative "utils"
+require "httparty"
 
 module NotionAPI
   # the initial methods available to an instantiated Cloent object are defined
   class Core
     include Utils
-    @options = { 'cookies' => { :token_v2 => nil, 'x-active-user-header' => nil }, 'headers' => { 'Content-Type' => 'application/json' } }
-    @type_whitelist = 'divider'
+    @options = { "cookies" => { :token_v2 => nil, "x-active-user-header" => nil }, "headers" => { "Content-Type" => "application/json" } }
+    @type_whitelist = "divider"
 
     class << self
       attr_reader :options, :type_whitelist, :token_v2, :active_user_header
@@ -30,11 +30,11 @@ module NotionAPI
         pageId: clean_id,
         chunkNumber: 0,
         limit: 100,
-        verticalColumns: false
+        verticalColumns: false,
       }
       jsonified_record_response = get_all_block_info(clean_id, request_body)
       i = 0
-      while jsonified_record_response.empty? || jsonified_record_response['block'].empty?
+      while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
         return {} if i >= 10
 
         jsonified_record_response = get_all_block_info(clean_id, request_body)
@@ -44,24 +44,26 @@ module NotionAPI
       block_type = extract_type(clean_id, jsonified_record_response)
       block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
 
-      raise 'the URL or ID passed to the get_page method must be that of a Page Block.' if !['collection_view_page', 'page'].include?(block_type)
+      raise ArgumentError, "the URL or ID passed to the get_page method must be that of a Page Block." if !["collection_view_page", "page"].include?(block_type)
 
-      if block_type == "page"
-        block_title = extract_title(clean_id, jsonified_record_response)
-        PageBlock.new(clean_id, block_title, block_parent_id)
-      elsif block_type == "collection_view_page"
-        collection_id = extract_collection_id(clean_id, jsonified_record_response)
-        block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
-        view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
-        schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
-        column_mappings = schema.keys
-        column_names = column_mappings.map { |mapping| schema[mapping]['name']}
+      instantiated_instance(block_type, clean_id, block_parent_id, jsonified_record_response)
 
-        collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
-        collection_view_page.instance_variable_set(:@column_names, column_names)
-        CollectionView.class_eval{attr_reader :column_names}
-        collection_view_page
-      end
+      # if block_type == "page"
+      #   block_title = extract_title(clean_id, jsonified_record_response)
+      #   PageBlock.new(clean_id, block_title, block_parent_id)
+      # elsif block_type == "collection_view_page"
+      #   collection_id = extract_collection_id(clean_id, jsonified_record_response)
+      #   block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
+      #   view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
+      #   schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
+      #   column_mappings = schema.keys
+      #   column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+
+      #   collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
+      #   collection_view_page.instance_variable_set(:@column_names, column_names)
+      #   CollectionView.class_eval { attr_reader :column_names }
+      #   collection_view_page
+      # end
     end
 
     def children(url_or_id = @id)
@@ -86,7 +88,7 @@ module NotionAPI
         pageId: clean_id,
         chunkNumber: 0,
         limit: 100,
-        verticalColumns: false
+        verticalColumns: false,
       }
       jsonified_record_response = get_all_block_info(clean_id, request_body)
       i = 0
@@ -97,7 +99,7 @@ module NotionAPI
         i += 1
       end
 
-      jsonified_record_response['block'][clean_id]['value']['content'] || []
+      jsonified_record_response["block"][clean_id]["value"]["content"] || []
     end
 
     private
@@ -105,19 +107,19 @@ module NotionAPI
     def get_notion_id(body)
       # ! retrieves a users ID from the headers of a Notion response object.
       # ! body -> the body to send in the request : ``Hash``
-      Core.options['cookies'][:token_v2] = @token_v2
-      Core.options['headers']['x-notion-active-user-header'] = @active_user_header
-      cookies = Core.options['cookies']
-      headers = Core.options['headers']
+      Core.options["cookies"][:token_v2] = @token_v2
+      Core.options["headers"]["x-notion-active-user-header"] = @active_user_header
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
       request_url = URLS[:GET_BLOCK]
 
       response = HTTParty.post(
         request_url,
         body: body.to_json,
         cookies: cookies,
-        headers: headers
+        headers: headers,
       )
-      response.headers['x-notion-user-id']
+      response.headers["x-notion-user-id"]
     end
 
     def get_last_page_block_id(url_or_id)
@@ -131,31 +133,31 @@ module NotionAPI
         pageId: clean_id,
         chunkNumber: 0,
         limit: 100,
-        verticalColumns: false
+        verticalColumns: false,
       }
       jsonified_record_response = get_all_block_info(clean_id, request_body)
       i = 0
       while jsonified_record_response.empty?
-        return {:properties => {title: [[block_title]]}, :format => {}} if i >= 10
+        return { :properties => { title: [[block_title]] }, :format => {} } if i >= 10
 
         jsonified_record_response = get_all_block_info(clean_id, request_body)
         i += 1
       end
-      properties = jsonified_record_response['block'][clean_id]['value']['properties']
-      formats = jsonified_record_response['block'][clean_id]['value']['format']
+      properties = jsonified_record_response["block"][clean_id]["value"]["properties"]
+      formats = jsonified_record_response["block"][clean_id]["value"]["format"]
       return {
-        :properties => properties,
-        :format => formats
-      }
+               :properties => properties,
+               :format => formats,
+             }
     end
 
     def get_all_block_info(_clean_id, body)
       # ! retrieves all info pertaining to a block Id.
       # ! clean_id -> the block ID or URL cleaned : ``str``
-      Core.options['cookies'][:token_v2] = @token_v2
-      Core.options['headers']['x-notion-active-user-header'] = @active_user_header
-      cookies = Core.options['cookies']
-      headers = Core.options['headers']
+      Core.options["cookies"][:token_v2] = @token_v2
+      Core.options["headers"]["x-notion-active-user-header"] = @active_user_header
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
 
       request_url = URLS[:GET_BLOCK]
 
@@ -163,16 +165,16 @@ module NotionAPI
         request_url,
         body: body.to_json,
         cookies: cookies,
-        headers: headers
+        headers: headers,
       )
 
-      JSON.parse(response.body)['recordMap']
+      JSON.parse(response.body)["recordMap"]
     end
 
     def filter_nil_blocks(jsonified_record_response)
       # ! removes any blocks that are empty [i.e. have no title / content]
       # ! jsonified_record_responses -> parsed JSON representation of a notion response object : ``Json``
-      jsonified_record_response.empty? || jsonified_record_response['block'].empty? ? nil : jsonified_record_response['block']
+      jsonified_record_response.empty? || jsonified_record_response["block"].empty? ? nil : jsonified_record_response["block"]
     end
 
     def extract_title(clean_id, jsonified_record_response)
@@ -180,14 +182,13 @@ module NotionAPI
       # ! clean_id -> the cleaned block ID: ``str``
       # ! jsonified_record_response -> parsed JSON representation of a notion response object : ``Json``
       filter_nil_blocks = filter_nil_blocks(jsonified_record_response)
-      if filter_nil_blocks.nil? || filter_nil_blocks[clean_id].nil? || filter_nil_blocks[clean_id]['value']['properties'].nil?
+      if filter_nil_blocks.nil? || filter_nil_blocks[clean_id].nil? || filter_nil_blocks[clean_id]["value"]["properties"].nil?
         nil
       else
         # titles for images are called source, while titles for text-based blocks are called title, so lets dynamically grab it
         # https://stackoverflow.com/questions/23765996/get-all-keys-from-ruby-hash/23766007
-        title_value = filter_nil_blocks[clean_id]['value']['properties'].keys[0]
-        Core.type_whitelist.include?(filter_nil_blocks[clean_id]['value']['type']) ? nil : jsonified_record_response['block'][clean_id]['value']['properties'][title_value].flatten[0] 
-
+        title_value = filter_nil_blocks[clean_id]["value"]["properties"].keys[0]
+        Core.type_whitelist.include?(filter_nil_blocks[clean_id]["value"]["type"]) ? nil : jsonified_record_response["block"][clean_id]["value"]["properties"][title_value].flatten[0]
       end
     end
 
@@ -196,7 +197,7 @@ module NotionAPI
       # ! clean_id -> the cleaned block ID: ``str``
       # ! collection_id -> the collection ID: ``str``
       # ! jsonified_record_response -> parsed JSON representation of a notion response object : ``Json``
-      jsonified_record_response['collection'][collection_id]['value']['name'].flatten.join if jsonified_record_response['collection'] and jsonified_record_response['collection'][collection_id]['value']['name']
+      jsonified_record_response["collection"][collection_id]["value"]["name"].flatten.join if jsonified_record_response["collection"] and jsonified_record_response["collection"][collection_id]["value"]["name"]
     end
 
     def extract_type(clean_id, jsonified_record_response)
@@ -207,8 +208,7 @@ module NotionAPI
       if filter_nil_blocks.nil?
         nil
       else
-        filter_nil_blocks[clean_id]['value']['type']
-
+        filter_nil_blocks[clean_id]["value"]["type"]
       end
     end
 
@@ -216,46 +216,46 @@ module NotionAPI
       # ! extract parent ID from core JSON response object.
       # ! clean_id -> the block ID or URL cleaned : ``str``
       # ! jsonified_record_response -> parsed JSON representation of a notion response object : ``Json``
-      jsonified_record_response.empty? || jsonified_record_response['block'].empty? ? {} : jsonified_record_response['block'][clean_id]['value']['parent_id']
+      jsonified_record_response.empty? || jsonified_record_response["block"].empty? ? {} : jsonified_record_response["block"][clean_id]["value"]["parent_id"]
     end
 
     def extract_collection_id(clean_id, jsonified_record_response)
       # ! extract the collection ID
       # ! clean_id -> the block ID or URL cleaned : ``str``
       # ! jsonified_record_response -> parsed JSON representation of a notion response object : ``Json``
-      jsonified_record_response['block'][clean_id]['value']['collection_id']
+      jsonified_record_response["block"][clean_id]["value"]["collection_id"]
     end
 
     def extract_view_ids(clean_id, jsonified_record_response)
-      jsonified_record_response['block'][clean_id]['value']['view_ids'] || []
+      jsonified_record_response["block"][clean_id]["value"]["view_ids"] || []
     end
-    
+
     def extract_id(url_or_id)
       # ! parse and clean the URL or ID object provided.
       # ! url_or_id -> the block ID or URL : ``str``
       http_or_https = url_or_id.match(/^(http|https)/) # true if http or https in url_or_id...
       collection_view_match = url_or_id.match(/(\?v=)/)
 
-      if (url_or_id.length == 36) && ((url_or_id.split('-').length == 5) && !http_or_https)
+      if (url_or_id.length == 36) && ((url_or_id.split("-").length == 5) && !http_or_https)
         # passes if url_or_id is perfectly formatted already...
         url_or_id
-      elsif (http_or_https && (url_or_id.split('-').last.length == 32)) || (!http_or_https && (url_or_id.length == 32)) || (collection_view_match)
+      elsif (http_or_https && (url_or_id.split("-").last.length == 32)) || (!http_or_https && (url_or_id.length == 32)) || (collection_view_match)
         # passes if either:
         # 1. a URL is passed as url_or_id and the ID at the end is 32 characters long or
         # 2. a URL is not passed and the ID length is 32 [aka unformatted]
         pattern = [8, 13, 18, 23]
         if collection_view_match
-          id_without_view = url_or_id.split('?')[0]
-          clean_id = id_without_view.split('/').last
-          pattern.each { |index| clean_id.insert(index, '-') }
+          id_without_view = url_or_id.split("?")[0]
+          clean_id = id_without_view.split("/").last
+          pattern.each { |index| clean_id.insert(index, "-") }
           clean_id
         else
-          id = url_or_id.split('-').last
-          pattern.each { |index| id.insert(index, '-') }
+          id = url_or_id.split("-").last
+          pattern.each { |index| id.insert(index, "-") }
           id
         end
       else
-        raise ArgumentError, 'Expected a Notion page URL or a page ID. Please consult the documentation for further information.'
+        raise ArgumentError, "Expected a Notion page URL or a page ID. Please consult the documentation for further information."
       end
     end
 
@@ -263,42 +263,72 @@ module NotionAPI
       # ! retrieve the collection scehma. Useful for 'building' the backbone for a table.
       # ! collection_id -> the collection ID : ``str``
       # ! view_id -> the view ID : ``str``
-      cookies = Core.options['cookies']
-      headers = Core.options['headers']
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
 
       if response.empty?
-        query_collection_hash = Utils::CollectionViewComponents.query_collection(collection_id, view_id, '')
+        query_collection_hash = Utils::CollectionViewComponents.query_collection(collection_id, view_id, "")
 
         request_url = URLS[:GET_COLLECTION]
         response = HTTParty.post(
           request_url,
           body: query_collection_hash.to_json,
           cookies: cookies,
-          headers: headers
+          headers: headers,
         )
-        response['recordMap']['collection'][collection_id]['value']['schema']
+        response["recordMap"]["collection"][collection_id]["value"]["schema"]
       else
-        response['collection'][collection_id]['value']['schema']
+        response["collection"][collection_id]["value"]["schema"]
       end
     end
-    
+
     def extract_collection_data(collection_id, view_id)
       # ! retrieve the collection scehma. Useful for 'building' the backbone for a table.
       # ! collection_id -> the collection ID : ``str``
       # ! view_id -> the view ID : ``str``
-      cookies = Core.options['cookies']
-      headers = Core.options['headers']
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
 
-      query_collection_hash = Utils::CollectionViewComponents.query_collection(collection_id, view_id, '')
+      query_collection_hash = Utils::CollectionViewComponents.query_collection(collection_id, view_id, "")
 
       request_url = URLS[:GET_COLLECTION]
       response = HTTParty.post(
         request_url,
         body: query_collection_hash.to_json,
         cookies: cookies,
-        headers: headers
+        headers: headers,
       )
-      response['recordMap']
+      response["recordMap"]
+    end
+
+    def retrieve_page_information(page_meta = {})
+      clean_id = page_meta.fetch(:clean_id)
+      jsonified_record_response = page_meta.fetch(:jsonified_record_response)
+      block_parent_id = page_meta.fetch(:parent_id)
+
+      block_title = extract_title(clean_id, jsonified_record_response)
+      PageBlock.new(clean_id, block_title, block_parent_id)
+    end
+
+    def retrieve_collection_view_page_information(**kwargs)
+      collection_id = extract_collection_id(clean_id, jsonified_record_response)
+      block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
+      view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
+      schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
+      column_mappings = schema.keys
+      column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+
+      collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
+      collection_view_page.instance_variable_set(:@column_names, column_names)
+      CollectionView.class_eval { attr_reader :column_names }
+      collection_view_page
+    end
+
+    def instantiated_instance(block_type, clean_id, parent_id, jsonified_record_response)
+      case block_type
+      when "page" then retrieve_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
+      when "collection_view_page" then retrieve_collection_view_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
+      end
     end
   end
 end

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -301,7 +301,10 @@ module NotionAPI
       response["recordMap"]
     end
 
-    def retrieve_page_information(page_meta = {})
+    def extract_page_information(page_meta = {})
+      # ! helper method for extracting information about a page block
+      # ! page_meta -> hash containing data points useful for the extraction of a page blocks information.
+      # !           This should include clean_id, jsonified_record_response, and parent_id
       clean_id = page_meta.fetch(:clean_id)
       jsonified_record_response = page_meta.fetch(:jsonified_record_response)
       block_parent_id = page_meta.fetch(:parent_id)
@@ -310,7 +313,10 @@ module NotionAPI
       PageBlock.new(clean_id, block_title, block_parent_id)
     end
 
-    def retrieve_collection_view_page_information(page_meta = {})
+    def extract_collection_view_page_information(page_meta = {})
+      # ! helper method for extracting information about a Collection View page block
+      # ! page_meta -> hash containing data points useful for the extraction of a page blocks information.
+      # !           This should include clean_id, jsonified_record_response, and parent_id
       clean_id = page_meta.fetch(:clean_id)
       jsonified_record_response = page_meta.fetch(:jsonified_record_response)
       block_parent_id = page_meta.fetch(:parent_id)
@@ -319,8 +325,7 @@ module NotionAPI
       block_title = extract_collection_title(clean_id, collection_id, jsonified_record_response)
       view_id = extract_view_ids(clean_id, jsonified_record_response)[0]
       schema = extract_collection_schema(collection_id, view_id, jsonified_record_response)
-      column_mappings = schema.keys
-      column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+      column_names = NotionAPI::CollectionView.extract_collection_view_column_names(schema)
 
       collection_view_page = CollectionViewPage.new(clean_id, block_title, block_parent_id, collection_id, view_id)
       collection_view_page.instance_variable_set(:@column_names, column_names)
@@ -330,8 +335,8 @@ module NotionAPI
 
     def instantiated_instance(block_type, clean_id, parent_id, jsonified_record_response)
       case block_type
-      when "page" then retrieve_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
-      when "collection_view_page" then retrieve_collection_view_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
+      when "page" then extract_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
+      when "collection_view_page" then extract_collection_view_page_information(clean_id: clean_id, parent_id: parent_id, jsonified_record_response: jsonified_record_response)
       end
     end
   end

--- a/lib/notion_api/notion_types/code_block.rb
+++ b/lib/notion_api/notion_types/code_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # Code block: used to store code, should be assigned a coding language.
-    class CodeBlock < BlockTemplate
-      @notion_type = 'code'
-      @type = 'code'
-  
-      def type
-        NotionAPI::CodeBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # Code block: used to store code, should be assigned a coding language.
+  class CodeBlock < BlockTemplate
+    @notion_type = "code"
+    @type = "code"
+
+    def type
+      NotionAPI::CodeBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/collection_view_blocks.rb
+++ b/lib/notion_api/notion_types/collection_view_blocks.rb
@@ -316,6 +316,14 @@ module NotionAPI
 
       prop_hash[prop_notion_name].split(" ").map { |word| word.gsub(/[^a-z0-9]/i, "").downcase }.join("_").to_sym
     end
+
+    def self.extract_collection_view_column_names(schema)
+      # ! extract the column names of a Collection View
+      # ! schema: the schema of the collection view
+      column_mappings = column_mappings = schema.keys
+      column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+      column_names
+    end
   end
 
   # class that represents each row in a CollectionView

--- a/lib/notion_api/notion_types/collection_view_blocks.rb
+++ b/lib/notion_api/notion_types/collection_view_blocks.rb
@@ -226,7 +226,6 @@ module NotionAPI
         # set instance variables for each column, allowing the dev to 'read' the column value
         cleaned_column = clean_property_names(column_hash, column)
 
-        # p row_data["value"]["properties"][column_mappings[i]], !(row_data["value"]["properties"][column] or row_data["value"]["properties"][column_mappings[i]])
         if row_data["value"]["properties"].nil? or row_data["value"]["properties"][column].nil?
           value = ""
         else

--- a/lib/notion_api/notion_types/collection_view_blocks.rb
+++ b/lib/notion_api/notion_types/collection_view_blocks.rb
@@ -158,20 +158,19 @@ module NotionAPI
         limit: 100,
         verticalColumns: false,
       }
-      jsonified_record_response = get_all_block_info(clean_id, request_body)
+      jsonified_record_response = get_all_block_info(request_body)
 
       i = 0
       while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
         return {} if i >= 10
 
-        jsonified_record_response = get_all_block_info(clean_id, request_body)
+        jsonified_record_response = get_all_block_info(request_body)
         i += 1
       end
 
       collection_data = extract_collection_data(@collection_id, @view_id)
       schema = collection_data["collection"][collection_id]["value"]["schema"]
-      column_mappings = schema.keys
-      column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+      column_names = NotionAPI::CollectionView.extract_collection_view_column_names(schema)
 
       collection_row = CollectionViewRow.new(row_id, @parent_id, @collection_id, @view_id)
       collection_row.instance_variable_set(:@column_names, column_names)
@@ -194,12 +193,12 @@ module NotionAPI
         verticalColumns: false,
       }
 
-      jsonified_record_response = get_all_block_info(clean_id, request_body)
+      jsonified_record_response = get_all_block_info(request_body)
       i = 0
       while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
         return {} if i >= 10
 
-        jsonified_record_response = get_all_block_info(clean_id, request_body)
+        jsonified_record_response = get_all_block_info(request_body)
         i += 1
       end
 
@@ -208,15 +207,13 @@ module NotionAPI
 
     def rows
       # ! returns all rows as instantiated class instances.
-      row_id_array = row_ids
+      row_id_array = row_ids()
       parent_id = @parent_id
       collection_id = @collection_id
       view_id = @view_id
       collection_data = extract_collection_data(@collection_id, @view_id)
       schema = collection_data["collection"][collection_id]["value"]["schema"]
-      column_mappings = schema.keys
-      column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
-
+      column_names = NotionAPI::CollectionView.extract_collection_view_column_names(schema)
       row_instances = row_id_array.map { |row_id| NotionAPI::CollectionViewRow.new(row_id, parent_id, collection_id, view_id) }
       clean_row_instances = row_instances.filter { |row| collection_data["block"][row.id] }
       clean_row_instances.each { |row| row.instance_variable_set(:@column_names, column_names) }

--- a/lib/notion_api/notion_types/collection_view_blocks.rb
+++ b/lib/notion_api/notion_types/collection_view_blocks.rb
@@ -160,14 +160,6 @@ module NotionAPI
       }
       jsonified_record_response = get_all_block_info(request_body)
 
-      i = 0
-      while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
-        return {} if i >= 10
-
-        jsonified_record_response = get_all_block_info(request_body)
-        i += 1
-      end
-
       collection_data = extract_collection_data(@collection_id, @view_id)
       schema = collection_data["collection"][collection_id]["value"]["schema"]
       column_names = NotionAPI::CollectionView.extract_collection_view_column_names(schema)
@@ -194,13 +186,6 @@ module NotionAPI
       }
 
       jsonified_record_response = get_all_block_info(request_body)
-      i = 0
-      while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
-        return {} if i >= 10
-
-        jsonified_record_response = get_all_block_info(request_body)
-        i += 1
-      end
 
       jsonified_record_response["collection_view"][@view_id]["value"]["page_sort"]
     end

--- a/lib/notion_api/notion_types/column_list_block.rb
+++ b/lib/notion_api/notion_types/column_list_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # no use case for this yet.
-    class ColumnListBlock < BlockTemplate
-      @notion_type = 'column_list'
-      @type = 'column_list'
-  
-      def type
-        NotionAPI::ColumnListBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # no use case for this yet.
+  class ColumnListBlock < BlockTemplate
+    @notion_type = "column_list"
+    @type = "column_list"
+
+    def type
+      NotionAPI::ColumnListBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/divider_block.rb
+++ b/lib/notion_api/notion_types/divider_block.rb
@@ -1,15 +1,15 @@
 module NotionAPI
-    # divider block: ---------
-    class DividerBlock < BlockTemplate
-      @notion_type = 'divider'
-      @type = 'divider'
-  
-      def type
-        NotionAPI::DividerBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # divider block: ---------
+  class DividerBlock < BlockTemplate
+    @notion_type = "divider"
+    @type = "divider"
+
+    def type
+      NotionAPI::DividerBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/header_block.rb
+++ b/lib/notion_api/notion_types/header_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # Header block: H1
-    class HeaderBlock < BlockTemplate
-      @notion_type = 'header'
-      @type = 'header'
-  
-      def type
-        NotionAPI::HeaderBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # Header block: H1
+  class HeaderBlock < BlockTemplate
+    @notion_type = "header"
+    @type = "header"
+
+    def type
+      NotionAPI::HeaderBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -14,12 +14,12 @@ module NotionAPI
     end
 
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
-      if !(options[:url])
-        raise ArgumentError, "Must specify URL Key as an option."
+      if !(options[:image])
+        raise ArgumentError, "Must specify image Key as an option."
       else
         cookies = Core.options["cookies"]
         headers = Core.options["headers"]
-        if options[:url].match(/^http:\/\/|^https:\/\//)
+        if options[:image].match(/^http:\/\/|^https:\/\//)
 
           create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
           set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
@@ -27,8 +27,8 @@ module NotionAPI
           last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
           last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
           title_hash = Utils::BlockComponents.title(new_block_id, block_title)
-          source_url_hash = Utils::BlockComponents.source(new_block_id, options[:url])
-          display_source_url_hash = Utils::BlockComponents.display_source(new_block_id, options[:url])
+          source_url_hash = Utils::BlockComponents.source(new_block_id, options[:image])
+          display_source_url_hash = Utils::BlockComponents.display_source(new_block_id, options[:image])
 
           operations = [
             create_hash,
@@ -53,18 +53,8 @@ module NotionAPI
               Please try again, and if issues persist open an issue in GitHub.";           end
 
           self.new(new_block_id, block_title, block_id)
-        elsif File.exist?(options[:url])
-          file_name = options[:url].split("/")[-1]
-          unformatted_content_type = file_name.split(".")[-1]
-          formatted_content_type = "image/#{unformatted_content_type}"
-          bucket = "secure"
-
-          p HTTParty.post(
-            "https://www.notion.so/api/v3/getUploadFileUrl",
-            body: {bucket: bucket, name: file_name, contentType: formatted_content_type}.to_json,
-            cookies: cookies,
-            headers: headers,
-          ).parsed_response["url"]
+          else
+            raise ArgumentError, "Currently, images can only be created through a public URL."
         end
       end
     end

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -14,7 +14,7 @@ module NotionAPI
     end
 
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
-      if !(options["url"] || options[:url])
+      if !(options["url"] || options[:url]) || (block_title.match(/^http:\/\/|^https:\/\//))
         raise ArgumentError, "Must specify URL Key as an option."
       end
       cookies = Core.options["cookies"]
@@ -26,6 +26,8 @@ module NotionAPI
       last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
       last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
       title_hash = Utils::BlockComponents.title(new_block_id, block_title)
+      source_url_hash = Utils::BlockComponents.source(new_block_id, options[:url])
+      display_source_url_hash = Utils::BlockComponents.display_source(new_block_id, options[:url])
 
       operations = [
         create_hash,
@@ -34,6 +36,8 @@ module NotionAPI
         last_edited_time_parent_hash,
         last_edited_time_child_hash,
         title_hash,
+        source_url_hash,
+        display_source_url_hash
       ]
 
       request_url = URLS[:UPDATE_BLOCK]

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -1,16 +1,53 @@
 module NotionAPI
 
-    # good for visual information
-    class ImageBlock < BlockTemplate
-      @notion_type = 'image'
-      @type = 'image'
-  
-      def type
-        NotionAPI::ImageBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # good for visual information
+  class ImageBlock < BlockTemplate
+    @notion_type = "image"
+    @type = "image"
+
+    def type
+      NotionAPI::ImageBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+
+    def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
+      if !(options["url"] || options[:url])
+        raise ArgumentError, "Must specify URL Key as an option."
+      end
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+
+      create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
+      set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
+      block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, new_block_id, target, position_command)
+      last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
+      last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
+      title_hash = Utils::BlockComponents.title(new_block_id, block_title)
+
+      operations = [
+        create_hash,
+        set_parent_alive_hash,
+        block_location_hash,
+        last_edited_time_parent_hash,
+        last_edited_time_child_hash,
+        title_hash,
+      ]
+
+      request_url = URLS[:UPDATE_BLOCK]
+      request_body = Utils::BlockComponents.build_payload(operations, request_ids)
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+           Please try again, and if issues persist open an issue in GitHub.";       end
+
+      self.new(new_block_id, block_title, block_id)
+    end
+  end
 end

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -14,44 +14,59 @@ module NotionAPI
     end
 
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
-      if !(options["url"] || options[:url]) || (block_title.match(/^http:\/\/|^https:\/\//))
+      if !(options[:url])
         raise ArgumentError, "Must specify URL Key as an option."
+      else
+        cookies = Core.options["cookies"]
+        headers = Core.options["headers"]
+        if options[:url].match(/^http:\/\/|^https:\/\//)
+
+          create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
+          set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
+          block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, new_block_id, target, position_command)
+          last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
+          last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
+          title_hash = Utils::BlockComponents.title(new_block_id, block_title)
+          source_url_hash = Utils::BlockComponents.source(new_block_id, options[:url])
+          display_source_url_hash = Utils::BlockComponents.display_source(new_block_id, options[:url])
+
+          operations = [
+            create_hash,
+            set_parent_alive_hash,
+            block_location_hash,
+            last_edited_time_parent_hash,
+            last_edited_time_child_hash,
+            title_hash,
+            source_url_hash,
+            display_source_url_hash,
+          ]
+
+          request_url = URLS[:UPDATE_BLOCK]
+          request_body = Utils::BlockComponents.build_payload(operations, request_ids)
+          response = HTTParty.post(
+            request_url,
+            body: request_body.to_json,
+            cookies: cookies,
+            headers: headers,
+          )
+          unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+              Please try again, and if issues persist open an issue in GitHub.";           end
+
+          self.new(new_block_id, block_title, block_id)
+        elsif File.exist?(options[:url])
+          file_name = options[:url].split("/")[-1]
+          unformatted_content_type = file_name.split(".")[-1]
+          formatted_content_type = "image/#{unformatted_content_type}"
+          bucket = "secure"
+
+          p HTTParty.post(
+            "https://www.notion.so/api/v3/getUploadFileUrl",
+            body: {bucket: bucket, name: file_name, contentType: formatted_content_type}.to_json,
+            cookies: cookies,
+            headers: headers,
+          ).parsed_response["url"]
+        end
       end
-      cookies = Core.options["cookies"]
-      headers = Core.options["headers"]
-
-      create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
-      set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
-      block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, new_block_id, target, position_command)
-      last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
-      last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
-      title_hash = Utils::BlockComponents.title(new_block_id, block_title)
-      source_url_hash = Utils::BlockComponents.source(new_block_id, options[:url])
-      display_source_url_hash = Utils::BlockComponents.display_source(new_block_id, options[:url])
-
-      operations = [
-        create_hash,
-        set_parent_alive_hash,
-        block_location_hash,
-        last_edited_time_parent_hash,
-        last_edited_time_child_hash,
-        title_hash,
-        source_url_hash,
-        display_source_url_hash
-      ]
-
-      request_url = URLS[:UPDATE_BLOCK]
-      request_body = Utils::BlockComponents.build_payload(operations, request_ids)
-      response = HTTParty.post(
-        request_url,
-        body: request_body.to_json,
-        cookies: cookies,
-        headers: headers,
-      )
-      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-           Please try again, and if issues persist open an issue in GitHub.";       end
-
-      self.new(new_block_id, block_title, block_id)
     end
   end
 end

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -17,12 +17,11 @@ module NotionAPI
 
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
       if !(options[:image])
-        raise ArgumentError, "Must specify image as an option. For example: {image: \"https://image-domain.com\"}"
+        raise ArgumentError, "Must specify image as an option. For example: .create(\"block type\", \"block title\", options: {image: \"https://image-domain.com\"})"
       else
         cookies = Core.options["cookies"]
         headers = Core.options["headers"]
         if options[:image].match(/^http:\/\/|^https:\/\//)
-
           create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
           set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
           block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, new_block_id, target, position_command)
@@ -55,8 +54,8 @@ module NotionAPI
               Please try again, and if issues persist open an issue in GitHub.";           end
 
           self.new(new_block_id, block_title, block_id)
-          else
-            raise ArgumentError, "Currently, images can only be created through a public image URL."
+        else
+          raise ArgumentError, "Currently, images can only be created through a public image URL."
         end
       end
     end

--- a/lib/notion_api/notion_types/image_block.rb
+++ b/lib/notion_api/notion_types/image_block.rb
@@ -13,9 +13,11 @@ module NotionAPI
       attr_reader :notion_type, :type
     end
 
+    private
+
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
       if !(options[:image])
-        raise ArgumentError, "Must specify image Key as an option."
+        raise ArgumentError, "Must specify image as an option. For example: {image: \"https://image-domain.com\"}"
       else
         cookies = Core.options["cookies"]
         headers = Core.options["headers"]
@@ -54,7 +56,7 @@ module NotionAPI
 
           self.new(new_block_id, block_title, block_id)
           else
-            raise ArgumentError, "Currently, images can only be created through a public URL."
+            raise ArgumentError, "Currently, images can only be created through a public image URL."
         end
       end
     end

--- a/lib/notion_api/notion_types/latex_block.rb
+++ b/lib/notion_api/notion_types/latex_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # simiilar to code block but for mathematical functions.
-    class LatexBlock < BlockTemplate
-      @notion_type = 'equation'
-      @type = 'equation'
-  
-      def type
-        NotionAPI::LatexBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # simiilar to code block but for mathematical functions.
+  class LatexBlock < BlockTemplate
+    @notion_type = "equation"
+    @type = "equation"
+
+    def type
+      NotionAPI::LatexBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/numbered_block.rb
+++ b/lib/notion_api/notion_types/numbered_block.rb
@@ -1,15 +1,15 @@
 module NotionAPI
-    # Numbered list Block: best for an ordered list
-    class NumberedBlock < BlockTemplate
-      @notion_type = 'numbered_list'
-      @type = 'numbered_list'
-  
-      def type
-        NotionAPI::NumberedBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # Numbered list Block: best for an ordered list
+  class NumberedBlock < BlockTemplate
+    @notion_type = "numbered_list"
+    @type = "numbered_list"
+
+    def type
+      NotionAPI::NumberedBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -31,12 +31,12 @@ module NotionAPI
           limit: 100,
           verticalColumns: false
         }
-        jsonified_record_response = get_all_block_info(clean_id, request_body)
+        jsonified_record_response = get_all_block_info(request_body)
         i = 0
         while jsonified_record_response.empty? || jsonified_record_response['block'].empty?
           return {} if i >= 10
   
-          jsonified_record_response = get_all_block_info(clean_id, request_body)
+          jsonified_record_response = get_all_block_info(request_body)
           i += 1
         end
         block_parent_id = extract_parent_id(clean_id, jsonified_record_response)

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -1,124 +1,123 @@
-
 module NotionAPI
 
-    # Page Block, entrypoint for the application
-    class PageBlock < BlockTemplate
-      @notion_type = 'page'
-      @type = 'page'
-  
-      def type
-        NotionAPI::PageBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
-  
-      def get_block(url_or_id)
-        # ! retrieve a Notion Block and return its instantiated class object.
-        # ! url_or_id -> the block ID or URL : ``str``
-        get(url_or_id)
-      end
-  
-      def get_collection(url_or_id)
-        # ! retrieve a Notion Collection and return its instantiated class object.
-        # ! url_or_id -> the block ID or URL : ``str``
-        clean_id = extract_id(url_or_id)
-  
-        request_body = {
-          pageId: clean_id,
-          chunkNumber: 0,
-          limit: 100,
-          verticalColumns: false
-        }
-        jsonified_record_response = get_all_block_info(request_body)
+  # Page Block, entrypoint for the application
+  class PageBlock < BlockTemplate
+    @notion_type = "page"
+    @type = "page"
 
-        block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
-        block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
-        block_view_id = extract_view_ids(clean_id, jsonified_record_response).join
-        block_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)
-  
-        CollectionView.new(clean_id, block_title, block_parent_id, block_collection_id, block_view_id)
-      end
-  
-      def create_collection(collection_type, collection_title, data)
-        # ! create a Notion Collection View and return its instantiated class object.
-        # ! _collection_type -> the type of collection to create : ``str``
-        # ! collection_title -> the title of the collection view : ``str``
-        # ! data -> JSON data to add to the table : ``str``
-  
-        valid_types = %w[table board list timeline calendar gallery]
-        unless valid_types.include?(collection_type) ; raise ArgumentError, "That collection type is not yet supported. Try: #{valid_types.join}."; end
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-  
-        new_block_id = extract_id(SecureRandom.hex(16))
-        parent_id = extract_id(SecureRandom.hex(16))
-        collection_id = extract_id(SecureRandom.hex(16))
-        view_id = extract_id(SecureRandom.hex(16))
-  
-        children = []
-        alive_blocks = []
-        data.each do |_row|
-          child = extract_id(SecureRandom.hex(16))
-          children.push(child)
-          alive_blocks.push(Utils::CollectionViewComponents.set_collection_blocks_alive(child, collection_id))
-        end
-  
-        request_id = extract_id(SecureRandom.hex(16))
-        transaction_id = extract_id(SecureRandom.hex(16))
-        space_id = extract_id(SecureRandom.hex(16))
-  
-        request_ids = {
-          request_id: request_id,
-          transaction_id: transaction_id,
-          space_id: space_id
-        }
-  
-        create_collection_view = Utils::CollectionViewComponents.create_collection_view(new_block_id, collection_id, view_id)
-        configure_view = Utils::CollectionViewComponents.set_view_config(collection_type, new_block_id, view_id, children)
-        
-        # returns the JSON and some useful column mappings...
-        column_data = Utils::CollectionViewComponents.set_collection_columns(collection_id, new_block_id, data)
-        configure_columns_hash = column_data[0]
-        column_mappings = column_data[1]
-        set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(@id, new_block_id)
-        add_block_hash = Utils::BlockComponents.block_location_add(@id, @id, new_block_id, nil, 'listAfter')
-        new_block_edited_time = Utils::BlockComponents.last_edited_time(new_block_id)
-        collection_title_hash = Utils::CollectionViewComponents.set_collection_title(collection_title, collection_id)
-  
-        operations = [
-          create_collection_view,
-          configure_view,
-          configure_columns_hash,
-          set_parent_alive_hash,
-          add_block_hash,
-          new_block_edited_time,
-          collection_title_hash
-        ]
-        operations << alive_blocks
-        all_ops = operations.flatten
-        data.each_with_index do |row, i|
-          child = children[i]
-          row.keys.each_with_index do |col_name, j|
-            child_component = Utils::CollectionViewComponents.insert_data(child, j.zero? ? 'title' : col_name, row[col_name], column_mappings[j])
-            all_ops.push(child_component)
-          end
-        end
-  
-        request_url = URLS[:UPDATE_BLOCK]
-        request_body = build_payload(all_ops, request_ids)
-        response = HTTParty.post(
-          request_url,
-          body: request_body.to_json,
-          cookies: cookies,
-          headers: headers
-        )
-  
-        unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-           Please try again, and if issues persist open an issue in GitHub."; end
-  
-        CollectionView.new(new_block_id, collection_title, parent_id, collection_id, view_id)
-      end
+    def type
+      NotionAPI::PageBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+
+    def get_block(url_or_id)
+      # ! retrieve a Notion Block and return its instantiated class object.
+      # ! url_or_id -> the block ID or URL : ``str``
+      get(url_or_id)
+    end
+
+    def get_collection(url_or_id)
+      # ! retrieve a Notion Collection and return its instantiated class object.
+      # ! url_or_id -> the block ID or URL : ``str``
+      clean_id = extract_id(url_or_id)
+
+      request_body = {
+        pageId: clean_id,
+        chunkNumber: 0,
+        limit: 100,
+        verticalColumns: false,
+      }
+      jsonified_record_response = get_all_block_info(request_body)
+
+      block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
+      block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
+      block_view_id = extract_view_ids(clean_id, jsonified_record_response).join
+      block_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)
+
+      CollectionView.new(clean_id, block_title, block_parent_id, block_collection_id, block_view_id)
+    end
+
+    def create_collection(collection_type, collection_title, data)
+      # ! create a Notion Collection View and return its instantiated class object.
+      # ! _collection_type -> the type of collection to create : ``str``
+      # ! collection_title -> the title of the collection view : ``str``
+      # ! data -> JSON data to add to the table : ``str``
+
+      valid_types = %w[table board list timeline calendar gallery]
+      unless valid_types.include?(collection_type); raise ArgumentError, "That collection type is not yet supported. Try: #{valid_types.join}."; end
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+
+      new_block_id = extract_id(SecureRandom.hex(16))
+      parent_id = extract_id(SecureRandom.hex(16))
+      collection_id = extract_id(SecureRandom.hex(16))
+      view_id = extract_id(SecureRandom.hex(16))
+
+      children = []
+      alive_blocks = []
+      data.each do |_row|
+        child = extract_id(SecureRandom.hex(16))
+        children.push(child)
+        alive_blocks.push(Utils::CollectionViewComponents.set_collection_blocks_alive(child, collection_id))
+      end
+
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+
+      create_collection_view = Utils::CollectionViewComponents.create_collection_view(new_block_id, collection_id, view_id)
+      configure_view = Utils::CollectionViewComponents.set_view_config(collection_type, new_block_id, view_id, children)
+
+      # returns the JSON and some useful column mappings...
+      column_data = Utils::CollectionViewComponents.set_collection_columns(collection_id, new_block_id, data)
+      configure_columns_hash = column_data[0]
+      column_mappings = column_data[1]
+      set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(@id, new_block_id)
+      add_block_hash = Utils::BlockComponents.block_location_add(@id, @id, new_block_id, nil, "listAfter")
+      new_block_edited_time = Utils::BlockComponents.last_edited_time(new_block_id)
+      collection_title_hash = Utils::CollectionViewComponents.set_collection_title(collection_title, collection_id)
+
+      operations = [
+        create_collection_view,
+        configure_view,
+        configure_columns_hash,
+        set_parent_alive_hash,
+        add_block_hash,
+        new_block_edited_time,
+        collection_title_hash,
+      ]
+      operations << alive_blocks
+      all_ops = operations.flatten
+      data.each_with_index do |row, i|
+        child = children[i]
+        row.keys.each_with_index do |col_name, j|
+          child_component = Utils::CollectionViewComponents.insert_data(child, j.zero? ? "title" : col_name, row[col_name], column_mappings[j])
+          all_ops.push(child_component)
+        end
+      end
+
+      request_url = URLS[:UPDATE_BLOCK]
+      request_body = build_payload(all_ops, request_ids)
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+
+      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+           Please try again, and if issues persist open an issue in GitHub.";       end
+
+      CollectionView.new(new_block_id, collection_title, parent_id, collection_id, view_id)
+    end
+  end
 end

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -32,13 +32,7 @@ module NotionAPI
           verticalColumns: false
         }
         jsonified_record_response = get_all_block_info(request_body)
-        i = 0
-        while jsonified_record_response.empty? || jsonified_record_response['block'].empty?
-          return {} if i >= 10
-  
-          jsonified_record_response = get_all_block_info(request_body)
-          i += 1
-        end
+
         block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
         block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
         block_view_id = extract_view_ids(clean_id, jsonified_record_response).join

--- a/lib/notion_api/notion_types/quote_block.rb
+++ b/lib/notion_api/notion_types/quote_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # best for memorable information
-    class QuoteBlock < BlockTemplate
-      @notion_type = 'quote'
-      @type = 'quote'
-  
-      def type
-        NotionAPI::QuoteBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # best for memorable information
+  class QuoteBlock < BlockTemplate
+    @notion_type = "quote"
+    @type = "quote"
+
+    def type
+      NotionAPI::QuoteBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/sub_header_block.rb
+++ b/lib/notion_api/notion_types/sub_header_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # SubHeader Block: H2
-    class SubHeaderBlock < BlockTemplate
-      @notion_type = 'sub_header'
-      @type = 'sub_header'
-  
-      def type
-        NotionAPI::SubHeaderBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # SubHeader Block: H2
+  class SubHeaderBlock < BlockTemplate
+    @notion_type = "sub_header"
+    @type = "sub_header"
+
+    def type
+      NotionAPI::SubHeaderBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/sub_sub_header.rb
+++ b/lib/notion_api/notion_types/sub_sub_header.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # Sub-Sub Header Block: H3
-    class SubSubHeaderBlock < BlockTemplate
-      @notion_type = 'sub_sub_header'
-      @type = 'sub_sub_header'
-  
-      def type
-        NotionAPI::SubSubHeaderBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # Sub-Sub Header Block: H3
+  class SubSubHeaderBlock < BlockTemplate
+    @notion_type = "sub_sub_header"
+    @type = "sub_sub_header"
+
+    def type
+      NotionAPI::SubSubHeaderBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/table_of_contents_block.rb
+++ b/lib/notion_api/notion_types/table_of_contents_block.rb
@@ -1,8 +1,8 @@
 module NotionAPI
   # maps out the headers - sub-headers - sub-sub-headers on the page
   class TableOfContentsBlock < BlockTemplate
-    @notion_type = 'table_of_contents'
-    @type = 'table_of_contents'
+    @notion_type = "table_of_contents"
+    @type = "table_of_contents"
 
     def type
       NotionAPI::TableOfContentsBlock.notion_type

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -289,13 +289,7 @@ module NotionAPI
         verticalColumns: false,
       }
       jsonified_record_response = get_all_block_info(request_body)
-      i = 0
-      while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
-        return {} if i >= 10
 
-        jsonified_record_response = get_all_block_info(request_body)
-        i += 1
-      end
       block_type = extract_type(clean_id, jsonified_record_response)
       block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
 

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -46,7 +46,7 @@ module NotionAPI
           space_id: space_id,
         }
 
-        # build hash's that contain the operations to send to Notions backend
+        # build hash's that contain the operations to send to Notion
         convert_type_hash = Utils::BlockComponents.convert_type(@id, block_class_to_convert_to)
         last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
         last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
@@ -229,8 +229,6 @@ module NotionAPI
         transaction_id: transaction_id,
         space_id: space_id,
       }
-      # TODO: try chopping off the self.create here.... so anything below this is done in the class method as opposed to the instance.
-      # then, the operations can be handled differently for different methods!
 
       block_type.create(@id, new_block_id, block_title, target, position_command, request_ids, options)
     end
@@ -238,7 +236,6 @@ module NotionAPI
     private
 
     def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
-      # TODO -> modularize this into create methods that override based on the class thats called
       blocks_with_emojis = [NotionAPI::PageBlock, NotionAPI::CalloutBlock]
       cookies = Core.options["cookies"]
       headers = Core.options["headers"]
@@ -291,12 +288,12 @@ module NotionAPI
         limit: 100,
         verticalColumns: false,
       }
-      jsonified_record_response = get_all_block_info(clean_id, request_body)
+      jsonified_record_response = get_all_block_info(request_body)
       i = 0
       while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
         return {} if i >= 10
 
-        jsonified_record_response = get_all_block_info(clean_id, request_body)
+        jsonified_record_response = get_all_block_info(request_body)
         i += 1
       end
       block_type = extract_type(clean_id, jsonified_record_response)

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -232,7 +232,6 @@ module NotionAPI
       # TODO: try chopping off the self.create here.... so anything below this is done in the class method as opposed to the instance.
       # then, the operations can be handled differently for different methods!
 
-      p options
       block_type.create(@id, new_block_id, block_title, target, position_command, request_ids, options)
     end
 

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -297,7 +297,7 @@ module NotionAPI
         {}
       else
         block_class = NotionAPI.const_get(BLOCK_TYPES[block_type].to_s)
-        if block_class == NotionAPI::CollectionView
+        if [NotionAPI::CollectionView,  NotionAPI::CollectionViewPage].include?(block_class)
           block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
           block_view_id = extract_view_ids(clean_id, jsonified_record_response)
           collection_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -1,360 +1,367 @@
-require_relative '../core'
-require 'httparty'
+require_relative "../core"
+require "httparty"
 
 module NotionAPI
-    # Base Template for all blocks. Inherits core methods from the Block class defined in block.rb
-    class BlockTemplate < Core
-      include Utils
-  
-      attr_reader :id, :title, :parent_id
-  
-      def initialize(id, title, parent_id)
-        @id = id
-        @title = title
-        @parent_id = parent_id
-      end
-  
-      def title=(new_title)
-        # ! Change the title of a block.
-        # ! new_title -> new title for the block : ``str``
-        request_id = extract_id(SecureRandom.hex(16))
-        transaction_id = extract_id(SecureRandom.hex(16))
-        space_id = extract_id(SecureRandom.hex(16))
-        update_title(new_title.to_s, request_id, transaction_id, space_id)
-        @title = new_title
-      end
-  
-      def convert(block_class_to_convert_to)
-        # ! convert a block from its current type to another.
-        # ! block_class_to_convert_to -> the type of block to convert to : ``cls``
-        if type == block_class_to_convert_to.notion_type
-          # if converting to same type, skip and return self
-          self
-        else
-          # setup cookies, headers, and grab/create static vars for request
-          cookies = Core.options['cookies']
-          headers = Core.options['headers']
-          request_url = URLS[:UPDATE_BLOCK]
-  
-          # set random IDs for request
-          request_id = extract_id(SecureRandom.hex(16))
-          transaction_id = extract_id(SecureRandom.hex(16))
-          space_id = extract_id(SecureRandom.hex(16))
-          request_ids = {
-            request_id: request_id,
-            transaction_id: transaction_id,
-            space_id: space_id
-          }
-  
-          # build hash's that contain the operations to send to Notions backend
-          convert_type_hash = Utils::BlockComponents.convert_type(@id, block_class_to_convert_to)
-          last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
-          last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-  
-          operations = [
-            convert_type_hash,
-            last_edited_time_parent_hash,
-            last_edited_time_child_hash
-          ]
-  
-          request_body = build_payload(operations, request_ids)
-          response = HTTParty.post(
-            request_url,
-            body: request_body.to_json,
-            cookies: cookies,
-            headers: headers
-          )
-          unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-             Please try again, and if issues persist open an issue in GitHub."; end
-  
-          block_class_to_convert_to.new(@id, @title, @parent_id)
-  
-        end
-      end
-  
-      def duplicate(target_block = nil)
-        # ! duplicate the block that this method is invoked upon.
-        # ! target_block -> the block to place the duplicated block after. Can be any valid Block ID! : ``str``
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-        request_url = URLS[:UPDATE_BLOCK]
-  
-        new_block_id = extract_id(SecureRandom.hex(16))
-        request_id = extract_id(SecureRandom.hex(16))
-        transaction_id = extract_id(SecureRandom.hex(16))
-        space_id = extract_id(SecureRandom.hex(16))
-  
-        root_children = children_ids(@id)
-        sub_children = []
-        root_children.each { |root_id| sub_children.push(children_ids(root_id)) }
-  
-        request_ids = {
-          request_id: request_id,
-          transaction_id: transaction_id,
-          space_id: space_id
-        }
-        body = {
-          pageId: @id,
-          chunkNumber: 0,
-          limit: 100,
-          verticalColumns: false
-        }
-  
-        user_notion_id = get_notion_id(body)
-  
-        block = target_block ? get(target_block) : self # allows dev to place block anywhere!
+  # Base Template for all blocks. Inherits core methods from the Block class defined in block.rb
+  class BlockTemplate < Core
+    include Utils
 
-        props_and_formatting = get_block_props_and_format(@id, @title)
-        props = props_and_formatting[:properties]
-        formats = props_and_formatting[:format]
-        duplicate_hash = Utils::BlockComponents.duplicate(type, @title, block.id, new_block_id, user_notion_id, root_children, props, formats)
-        set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block.parent_id, new_block_id)
-        block_location_hash = Utils::BlockComponents.block_location_add(block.parent_id, block.id, new_block_id, target_block, 'listAfter')
-        last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block.parent_id)
-        last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block.id)
-  
-        operations = [
-          duplicate_hash,
-          set_parent_alive_hash,
-          block_location_hash,
-          last_edited_time_parent_hash,
-          last_edited_time_child_hash
-        ]
-  
-        request_body = build_payload(operations, request_ids)
-        response = HTTParty.post(
-          request_url,
-          body: request_body.to_json,
-          cookies: cookies,
-          headers: headers
-        )
-        unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-           Please try again, and if issues persist open an issue in GitHub."; end
-  
-        class_to_return = NotionAPI.const_get(Classes.select { |cls| NotionAPI.const_get(cls).notion_type == type }.join.to_s)
-        class_to_return.new(new_block_id, @title, block.parent_id)
-      end
-  
-      def move(target_block, position = 'after')
-        # ! move the block to a new location.
-        # ! target_block -> the targetted block to move to. : ``str``
-        # ! position -> where the block should be listed, in positions relative to the target_block [before, after, top-child, last-child]
-        positions_hash = {
-          'after' => 'listAfter',
-          'before' => 'listBefore'
-        }
-  
-        unless positions_hash.keys.include?(position); raise ArgumentError, "Invalid position. You said: #{position}, valid options are: #{positions_hash.keys.join(', ')}"; end
-  
-        position_command = positions_hash[position]
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-        request_url = URLS[:UPDATE_BLOCK]
-  
-        request_id = extract_id(SecureRandom.hex(16))
-        transaction_id = extract_id(SecureRandom.hex(16))
-        space_id = extract_id(SecureRandom.hex(16))
-  
-        request_ids = {
-          request_id: request_id,
-          transaction_id: transaction_id,
-          space_id: space_id
-        }
-  
-        check_parents = (@parent_id == target_block.parent_id)
-        set_block_dead_hash = Utils::BlockComponents.set_block_to_dead(@id) # kill the block this method is invoked on...
-        block_location_remove_hash = Utils::BlockComponents.block_location_remove(@parent_id, @id) # remove the block this method is invoked on...
-        parent_location_hash = Utils::BlockComponents.parent_location_add(check_parents ? @parent_id : target_block.parent_id, @id) # set parent location to alive
-        block_location_add_hash = Utils::BlockComponents.block_location_add(check_parents ? @parent_id : target_block.parent_id, @id, target_block.id, position_command)
-        last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
-  
-        if check_parents
-          last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-          operations = [
-            set_block_dead_hash,
-            block_location_remove_hash,
-            parent_location_hash,
-            block_location_add_hash,
-            last_edited_time_parent_hash,
-            last_edited_time_child_hash
-          ]
-        else
-          last_edited_time_new_parent_hash = Utils::BlockComponents.last_edited_time(target_block.parent_id)
-          last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-          @parent_id = target_block.parent_id
-          operations = [
-            set_block_dead_hash,
-            block_location_remove_hash,
-            parent_location_hash,
-            block_location_add_hash,
-            last_edited_time_parent_hash,
-            last_edited_time_new_parent_hash,
-            last_edited_time_child_hash
-          ]
-        end
-        request_body = build_payload(operations, request_ids)
-        response = HTTParty.post(
-          request_url,
-          body: request_body.to_json,
-          cookies: cookies,
-          headers: headers
-        )
-        unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-           Please try again, and if issues persist open an issue in GitHub."; end
-  
+    attr_reader :id, :title, :parent_id
+
+    def initialize(id, title, parent_id)
+      @id = id
+      @title = title
+      @parent_id = parent_id
+    end
+
+    def title=(new_title)
+      # ! Change the title of a block.
+      # ! new_title -> new title for the block : ``str``
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+      update_title(new_title.to_s, request_id, transaction_id, space_id)
+      @title = new_title
+    end
+
+    def convert(block_class_to_convert_to)
+      # ! convert a block from its current type to another.
+      # ! block_class_to_convert_to -> the type of block to convert to : ``cls``
+      if type == block_class_to_convert_to.notion_type
+        # if converting to same type, skip and return self
         self
-      end
-  
-      def create(block_type, block_title, target = nil, position = 'after')
-        # ! create a new block
-        # ! block_type -> the type of block to create : ``cls``
-        # ! block_title -> the title of the new block : ``str``
-        # ! target -> the block_id that the new block should be placed after. ``str`` 
-        # ! position -> 'after' or 'before'
-        positions_hash = {
-          'after' => 'listAfter',
-          'before' => 'listBefore'
-        }
-        unless positions_hash.keys.include?(position); raise "Invalid position. You said: #{position}, valid options are: #{positions_hash.keys.join(', ')}"; end
-  
-        position_command = positions_hash[position]
-        blocks_with_emojis = [NotionAPI::PageBlock, NotionAPI::CalloutBlock]
-  
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-  
-        new_block_id = extract_id(SecureRandom.hex(16))
+      else
+        # setup cookies, headers, and grab/create static vars for request
+        cookies = Core.options["cookies"]
+        headers = Core.options["headers"]
+        request_url = URLS[:UPDATE_BLOCK]
+
+        # set random IDs for request
         request_id = extract_id(SecureRandom.hex(16))
         transaction_id = extract_id(SecureRandom.hex(16))
         space_id = extract_id(SecureRandom.hex(16))
-  
         request_ids = {
           request_id: request_id,
           transaction_id: transaction_id,
-          space_id: space_id
+          space_id: space_id,
         }
-  
-        create_hash = Utils::BlockComponents.create(new_block_id, block_type.notion_type)
-        set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(@id, new_block_id)
-        block_location_hash = Utils::BlockComponents.block_location_add(@id, @id, new_block_id, target, position_command)
-        last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@id)
+
+        # build hash's that contain the operations to send to Notions backend
+        convert_type_hash = Utils::BlockComponents.convert_type(@id, block_class_to_convert_to)
+        last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
         last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-        title_hash = Utils::BlockComponents.title(new_block_id, block_title)
 
         operations = [
-          create_hash,
-          set_parent_alive_hash,
-          block_location_hash,
+          convert_type_hash,
           last_edited_time_parent_hash,
           last_edited_time_child_hash,
-          title_hash
         ]
 
-        if blocks_with_emojis.include?(block_type)
-          emoji_choices = ["😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "😀", "😃"]
-          emoji = emoji_choices[rand(0...emoji_choices.length)]
-          emoji_icon_hash = Utils::BlockComponents.add_emoji_icon(new_block_id, emoji)
-          operations.push(emoji_icon_hash)
-        end
-  
-  
-        request_url = URLS[:UPDATE_BLOCK]
         request_body = build_payload(operations, request_ids)
         response = HTTParty.post(
           request_url,
           body: request_body.to_json,
           cookies: cookies,
-          headers: headers
+          headers: headers,
         )
         unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-           Please try again, and if issues persist open an issue in GitHub."; end
-  
-        block_type.new(new_block_id, block_title, @id)
-      end
-  
-      private
-  
-      def get(url_or_id)
-        # ! retrieve a Notion Block and return its instantiated class object.
-        # ! url_or_id -> the block ID or URL : ``str``
-        clean_id = extract_id(url_or_id)
-  
-        request_body = {
-          pageId: clean_id,
-          chunkNumber: 0,
-          limit: 100,
-          verticalColumns: false
-        }
-        jsonified_record_response = get_all_block_info(clean_id, request_body)
-        i = 0
-        while jsonified_record_response.empty? || jsonified_record_response['block'].empty?
-          return {} if i >= 10
-  
-          jsonified_record_response = get_all_block_info(clean_id, request_body)
-          i += 1
-        end
-        block_type = extract_type(clean_id, jsonified_record_response)
-        block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
-  
-        if block_type.nil?
-          {}
-        else
-          block_class = NotionAPI.const_get(BLOCK_TYPES[block_type].to_s)
-          if block_class == NotionAPI::CollectionView
-            block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
-            block_view_id = extract_view_ids(clean_id, jsonified_record_response)
-            collection_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)
-            
-            block = block_class.new(clean_id, collection_title, block_parent_id, block_collection_id, block_view_id.join)
-            schema = extract_collection_schema(block_collection_id, block_view_id[0])
-            column_mappings = schema.keys
-            column_names = column_mappings.map { |mapping| schema[mapping]['name']}
-            block.instance_variable_set(:@column_names, column_names)
-            CollectionView.class_eval{attr_reader :column_names}
+             Please try again, and if issues persist open an issue in GitHub.";         end
 
-            block
-          else
-            block_title = extract_title(clean_id, jsonified_record_response)
-            block_class.new(clean_id, block_title, block_parent_id)
-          end
-        end
-      end
-  
-      def update_title(new_title, request_id, transaction_id, space_id)
-        # ! Helper method for sending POST request to change title of block.
-        # ! new_title -> new title for the block : ``str``
-        # ! request_id -> the unique ID for the request key. Generated using SecureRandom : ``str``
-        # ! transaction_id -> the unique ID for the transaction key. Generated using SecureRandom: ``str``
-        # ! transaction_id -> the unique ID for the space key. Generated using SecureRandom: ``str``
-        # setup cookies, headers, and grab/create static vars for request
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-        request_url = URLS[:UPDATE_BLOCK]
-  
-        # set unique IDs for request
-        request_ids = {
-          request_id: request_id,
-          transaction_id: transaction_id,
-          space_id: space_id
-        }
-  
-        # build and set operations to send to Notion
-        title_hash = Utils::BlockComponents.title(@id, new_title)
-        last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-        operations = [
-          title_hash,
-          last_edited_time_child_hash
-        ]
-  
-        request_body = build_payload(operations, request_ids) # defined in utils.rb
-  
-        response = HTTParty.post(
-          request_url,
-          body: request_body.to_json,
-          cookies: cookies,
-          headers: headers
-        )
-        response.body
+        block_class_to_convert_to.new(@id, @title, @parent_id)
       end
     end
+
+    def duplicate(target_block = nil)
+      # ! duplicate the block that this method is invoked upon.
+      # ! target_block -> the block to place the duplicated block after. Can be any valid Block ID! : ``str``
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+      request_url = URLS[:UPDATE_BLOCK]
+
+      new_block_id = extract_id(SecureRandom.hex(16))
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+
+      root_children = children_ids(@id)
+      sub_children = []
+      root_children.each { |root_id| sub_children.push(children_ids(root_id)) }
+
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+      body = {
+        pageId: @id,
+        chunkNumber: 0,
+        limit: 100,
+        verticalColumns: false,
+      }
+
+      user_notion_id = get_notion_id(body)
+
+      block = target_block ? get(target_block) : self # allows dev to place block anywhere!
+
+      props_and_formatting = get_block_props_and_format(@id, @title)
+      props = props_and_formatting[:properties]
+      formats = props_and_formatting[:format]
+      duplicate_hash = Utils::BlockComponents.duplicate(type, @title, block.id, new_block_id, user_notion_id, root_children, props, formats)
+      set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block.parent_id, new_block_id)
+      block_location_hash = Utils::BlockComponents.block_location_add(block.parent_id, block.id, new_block_id, target_block, "listAfter")
+      last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block.parent_id)
+      last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block.id)
+
+      operations = [
+        duplicate_hash,
+        set_parent_alive_hash,
+        block_location_hash,
+        last_edited_time_parent_hash,
+        last_edited_time_child_hash,
+      ]
+
+      request_body = build_payload(operations, request_ids)
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+           Please try again, and if issues persist open an issue in GitHub.";       end
+
+      class_to_return = NotionAPI.const_get(Classes.select { |cls| NotionAPI.const_get(cls).notion_type == type }.join.to_s)
+      class_to_return.new(new_block_id, @title, block.parent_id)
+    end
+
+    def move(target_block, position = "after")
+      # ! move the block to a new location.
+      # ! target_block -> the targetted block to move to. : ``str``
+      # ! position -> where the block should be listed, in positions relative to the target_block [before, after, top-child, last-child]
+      positions_hash = {
+        "after" => "listAfter",
+        "before" => "listBefore",
+      }
+
+      unless positions_hash.keys.include?(position); raise ArgumentError, "Invalid position. You said: #{position}, valid options are: #{positions_hash.keys.join(", ")}"; end
+
+      position_command = positions_hash[position]
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+      request_url = URLS[:UPDATE_BLOCK]
+
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+
+      check_parents = (@parent_id == target_block.parent_id)
+      set_block_dead_hash = Utils::BlockComponents.set_block_to_dead(@id) # kill the block this method is invoked on...
+      block_location_remove_hash = Utils::BlockComponents.block_location_remove(@parent_id, @id) # remove the block this method is invoked on...
+      parent_location_hash = Utils::BlockComponents.parent_location_add(check_parents ? @parent_id : target_block.parent_id, @id) # set parent location to alive
+      block_location_add_hash = Utils::BlockComponents.block_location_add(check_parents ? @parent_id : target_block.parent_id, @id, target_block.id, position_command)
+      last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
+
+      if check_parents
+        last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
+        operations = [
+          set_block_dead_hash,
+          block_location_remove_hash,
+          parent_location_hash,
+          block_location_add_hash,
+          last_edited_time_parent_hash,
+          last_edited_time_child_hash,
+        ]
+      else
+        last_edited_time_new_parent_hash = Utils::BlockComponents.last_edited_time(target_block.parent_id)
+        last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
+        @parent_id = target_block.parent_id
+        operations = [
+          set_block_dead_hash,
+          block_location_remove_hash,
+          parent_location_hash,
+          block_location_add_hash,
+          last_edited_time_parent_hash,
+          last_edited_time_new_parent_hash,
+          last_edited_time_child_hash,
+        ]
+      end
+      request_body = build_payload(operations, request_ids)
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+           Please try again, and if issues persist open an issue in GitHub.";       end
+
+      self
+    end
+
+    def create(block_type, block_title, target = nil, position = "after", options: {})
+      # ! create a new block
+      # ! block_type -> the type of block to create : ``cls``
+      # ! block_title -> the title of the new block : ``str``
+      # ! target -> the block_id that the new block should be placed after. ``str``
+      # ! position -> 'after' or 'before'
+
+      positions_hash = {
+        "after" => "listAfter",
+        "before" => "listBefore",
+      }
+      unless positions_hash.keys.include?(position); raise "Invalid position. You said: #{position}, valid options are: #{positions_hash.keys.join(", ")}"; end
+
+      position_command = positions_hash[position]
+
+      new_block_id = extract_id(SecureRandom.hex(16))
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+      # TODO: try chopping off the self.create here.... so anything below this is done in the class method as opposed to the instance.
+      # then, the operations can be handled differently for different methods!
+
+      p options
+      block_type.create(@id, new_block_id, block_title, target, position_command, request_ids, options)
+    end
+
+    private
+
+    def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
+      # TODO -> modularize this into create methods that override based on the class thats called
+      blocks_with_emojis = [NotionAPI::PageBlock, NotionAPI::CalloutBlock]
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+
+      create_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
+      set_parent_alive_hash = Utils::BlockComponents.set_parent_to_alive(block_id, new_block_id)
+      block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, new_block_id, target, position_command)
+      last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(block_id)
+      last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(block_id)
+      title_hash = Utils::BlockComponents.title(new_block_id, block_title)
+
+      operations = [
+        create_hash,
+        set_parent_alive_hash,
+        block_location_hash,
+        last_edited_time_parent_hash,
+        last_edited_time_child_hash,
+        title_hash,
+      ]
+
+      if blocks_with_emojis.include?(self)
+        emoji_choices = ["😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "😀", "😃"]
+        emoji = emoji_choices[rand(0...emoji_choices.length)]
+        emoji_icon_hash = Utils::BlockComponents.add_emoji_icon(new_block_id, emoji)
+        operations.push(emoji_icon_hash)
+      end
+
+      request_url = URLS[:UPDATE_BLOCK]
+      request_body = Utils::BlockComponents.build_payload(operations, request_ids)
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+      unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+           Please try again, and if issues persist open an issue in GitHub.";       end
+
+      self.new(new_block_id, block_title, block_id)
+    end
+
+    def get(url_or_id)
+      # ! retrieve a Notion Block and return its instantiated class object.
+      # ! url_or_id -> the block ID or URL : ``str``
+      clean_id = extract_id(url_or_id)
+
+      request_body = {
+        pageId: clean_id,
+        chunkNumber: 0,
+        limit: 100,
+        verticalColumns: false,
+      }
+      jsonified_record_response = get_all_block_info(clean_id, request_body)
+      i = 0
+      while jsonified_record_response.empty? || jsonified_record_response["block"].empty?
+        return {} if i >= 10
+
+        jsonified_record_response = get_all_block_info(clean_id, request_body)
+        i += 1
+      end
+      block_type = extract_type(clean_id, jsonified_record_response)
+      block_parent_id = extract_parent_id(clean_id, jsonified_record_response)
+
+      if block_type.nil?
+        {}
+      else
+        block_class = NotionAPI.const_get(BLOCK_TYPES[block_type].to_s)
+        if block_class == NotionAPI::CollectionView
+          block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
+          block_view_id = extract_view_ids(clean_id, jsonified_record_response)
+          collection_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)
+
+          block = block_class.new(clean_id, collection_title, block_parent_id, block_collection_id, block_view_id.join)
+          schema = extract_collection_schema(block_collection_id, block_view_id[0])
+          column_mappings = schema.keys
+          column_names = column_mappings.map { |mapping| schema[mapping]["name"] }
+          block.instance_variable_set(:@column_names, column_names)
+          CollectionView.class_eval { attr_reader :column_names }
+
+          block
+        else
+          block_title = extract_title(clean_id, jsonified_record_response)
+          block_class.new(clean_id, block_title, block_parent_id)
+        end
+      end
+    end
+
+    def update_title(new_title, request_id, transaction_id, space_id)
+      # ! Helper method for sending POST request to change title of block.
+      # ! new_title -> new title for the block : ``str``
+      # ! request_id -> the unique ID for the request key. Generated using SecureRandom : ``str``
+      # ! transaction_id -> the unique ID for the transaction key. Generated using SecureRandom: ``str``
+      # ! transaction_id -> the unique ID for the space key. Generated using SecureRandom: ``str``
+      # setup cookies, headers, and grab/create static vars for request
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+      request_url = URLS[:UPDATE_BLOCK]
+
+      # set unique IDs for request
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+
+      # build and set operations to send to Notion
+      title_hash = Utils::BlockComponents.title(@id, new_title)
+      last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
+      operations = [
+        title_hash,
+        last_edited_time_child_hash,
+      ]
+
+      request_body = build_payload(operations, request_ids) # defined in utils.rb
+
+      response = HTTParty.post(
+        request_url,
+        body: request_body.to_json,
+        cookies: cookies,
+        headers: headers,
+      )
+      response.body
+    end
+  end
 end

--- a/lib/notion_api/notion_types/template.rb
+++ b/lib/notion_api/notion_types/template.rb
@@ -160,14 +160,14 @@ module NotionAPI
         space_id: space_id,
       }
 
-      check_parents = (@parent_id == target_block.parent_id)
+      is_same_parent = (@parent_id == target_block.parent_id)
       set_block_dead_hash = Utils::BlockComponents.set_block_to_dead(@id) # kill the block this method is invoked on...
       block_location_remove_hash = Utils::BlockComponents.block_location_remove(@parent_id, @id) # remove the block this method is invoked on...
-      parent_location_hash = Utils::BlockComponents.parent_location_add(check_parents ? @parent_id : target_block.parent_id, @id) # set parent location to alive
-      block_location_add_hash = Utils::BlockComponents.block_location_add(check_parents ? @parent_id : target_block.parent_id, @id, target_block.id, position_command)
+      parent_location_hash = Utils::BlockComponents.parent_location_add(is_same_parent ? @parent_id : target_block.parent_id, @id) # set parent location to alive
+      block_location_add_hash = Utils::BlockComponents.block_location_add(is_same_parent ? @parent_id : target_block.parent_id, @id, target_block.id, position_command)
       last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
 
-      if check_parents
+      if is_same_parent
         last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
         operations = [
           set_block_dead_hash,
@@ -297,7 +297,7 @@ module NotionAPI
         {}
       else
         block_class = NotionAPI.const_get(BLOCK_TYPES[block_type].to_s)
-        if [NotionAPI::CollectionView,  NotionAPI::CollectionViewPage].include?(block_class)
+        if [NotionAPI::CollectionView, NotionAPI::CollectionViewPage].include?(block_class)
           block_collection_id = extract_collection_id(clean_id, jsonified_record_response)
           block_view_id = extract_view_ids(clean_id, jsonified_record_response)
           collection_title = extract_collection_title(clean_id, block_collection_id, jsonified_record_response)

--- a/lib/notion_api/notion_types/text_block.rb
+++ b/lib/notion_api/notion_types/text_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # good for just about anything (-:
-    class TextBlock < BlockTemplate
-      @notion_type = 'text'
-      @type = 'text'
-  
-      def type
-        NotionAPI::TextBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # good for just about anything (-:
+  class TextBlock < BlockTemplate
+    @notion_type = "text"
+    @type = "text"
+
+    def type
+      NotionAPI::TextBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/notion_types/todo_block.rb
+++ b/lib/notion_api/notion_types/todo_block.rb
@@ -1,60 +1,60 @@
 module NotionAPI
 
-    # To-Do block: best for checklists and tracking to-dos.
-    class TodoBlock < BlockTemplate
-      @notion_type = 'to_do'
-      @type = 'to_do'
-  
-      def type
-        NotionAPI::TodoBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
-  
-      def checked=(checked_value)
-        # ! change the checked property of the Todo Block.
-        # ! checked_value -> boolean value used to determine whether the block should be checked [yes] or not [no] : ``str``
-        # set static variables for request
-        cookies = Core.options['cookies']
-        headers = Core.options['headers']
-        request_url = URLS[:UPDATE_BLOCK]
-  
-        # set unique values for request
-        request_id = extract_id(SecureRandom.hex(16))
-        transaction_id = extract_id(SecureRandom.hex(16))
-        space_id = extract_id(SecureRandom.hex(16))
-        request_ids = {
-          request_id: request_id,
-          transaction_id: transaction_id,
-          space_id: space_id
-        }
-  
-        if %w[yes no].include?(checked_value.downcase)
-          checked_hash = Utils::BlockComponents.checked_todo(@id, checked_value.downcase)
-          last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
-          last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
-  
-          operations = [
-            checked_hash,
-            last_edited_time_parent_hash,
-            last_edited_time_child_hash
-          ]
-          request_body = build_payload(operations, request_ids)
-          response = HTTParty.post(
-            request_url,
-            body: request_body.to_json,
-            cookies: cookies,
-            headers: headers
-          )
-          unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
-             Please try again, and if issues persist open an issue in GitHub."; end
-  
-          true
-        else
-          false
-        end
+  # To-Do block: best for checklists and tracking to-dos.
+  class TodoBlock < BlockTemplate
+    @notion_type = "to_do"
+    @type = "to_do"
+
+    def type
+      NotionAPI::TodoBlock.notion_type
+    end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+
+    def checked=(checked_value)
+      # ! change the checked property of the Todo Block.
+      # ! checked_value -> boolean value used to determine whether the block should be checked [yes] or not [no] : ``str``
+      # set static variables for request
+      cookies = Core.options["cookies"]
+      headers = Core.options["headers"]
+      request_url = URLS[:UPDATE_BLOCK]
+
+      # set unique values for request
+      request_id = extract_id(SecureRandom.hex(16))
+      transaction_id = extract_id(SecureRandom.hex(16))
+      space_id = extract_id(SecureRandom.hex(16))
+      request_ids = {
+        request_id: request_id,
+        transaction_id: transaction_id,
+        space_id: space_id,
+      }
+
+      if %w[yes no].include?(checked_value.downcase)
+        checked_hash = Utils::BlockComponents.checked_todo(@id, checked_value.downcase)
+        last_edited_time_parent_hash = Utils::BlockComponents.last_edited_time(@parent_id)
+        last_edited_time_child_hash = Utils::BlockComponents.last_edited_time(@id)
+
+        operations = [
+          checked_hash,
+          last_edited_time_parent_hash,
+          last_edited_time_child_hash,
+        ]
+        request_body = build_payload(operations, request_ids)
+        response = HTTParty.post(
+          request_url,
+          body: request_body.to_json,
+          cookies: cookies,
+          headers: headers,
+        )
+        unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+             Please try again, and if issues persist open an issue in GitHub.";         end
+
+        true
+      else
+        false
       end
     end
+  end
 end

--- a/lib/notion_api/notion_types/toggle_block.rb
+++ b/lib/notion_api/notion_types/toggle_block.rb
@@ -1,16 +1,16 @@
 module NotionAPI
 
-    # Toggle block: best for storing children blocks
-    class ToggleBlock < BlockTemplate
-      @notion_type = 'toggle'
-      @type = 'toggle'
-  
-      def type
-        NotionAPI::ToggleBlock.notion_type
-      end
-  
-      class << self
-        attr_reader :notion_type, :type
-      end
+  # Toggle block: best for storing children blocks
+  class ToggleBlock < BlockTemplate
+    @notion_type = "toggle"
+    @type = "toggle"
+
+    def type
+      NotionAPI::ToggleBlock.notion_type
     end
+
+    class << self
+      attr_reader :notion_type, :type
+    end
+  end
 end

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -709,7 +709,7 @@ module Utils
     end
   end
 
-  def self.build_payload(operations, request_ids)
+  def build_payload(operations, request_ids)
     # ! properly formats the payload for Notions backend.
     # ! operations -> an array of hashes that define the operations to perform : ``Array[Hash]``
     # ! request_ids -> the unique IDs for the request : ``str``

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -317,6 +317,7 @@ module Utils
         command: "set", "args": icon,
       }
     end
+
     def self.source(new_block_id, url)
       table = "block"
       path = ["properties"]
@@ -336,18 +337,17 @@ module Utils
     end
 
     def self.display_source(new_block_id, block_url)
-
       {
         "id": new_block_id,
         "table": "block",
         "path": [
-            "format"
+          "format",
         ],
         "command": "update",
         "args": {
-            "display_source": block_url
-        }
-    }
+          "display_source": block_url,
+        },
+      }
     end
   end
 

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -241,6 +241,10 @@ module Utils
     end
 
     def self.row_location_add(last_row_id, block_id, view_id)
+      # ! add a new row to a Collection View table
+      # ! last_row_id -> ID of the last row in the CV : ``str``
+      # ! block_id -> ID of the blow : ``str``
+      # ! view_id -> ID of the View : ``str``
       {
         "table": "collection_view",
         "id": view_id,
@@ -310,6 +314,9 @@ module Utils
       }
     end
     def self.add_emoji_icon(block_id, icon)
+      # ! add an emoji icon for either a page or callout block
+      # ! block_id -> the ID of the block : ``str``
+      # ! icon -> the icon for the block. This is currently randomly chosen. : ``str``
       {
         id: block_id,
         table: "block",
@@ -319,6 +326,9 @@ module Utils
     end
 
     def self.source(new_block_id, url)
+      # ! set the source for the ImageBlock
+      # ! new_block_id -> the ID of the new ImageBlock: ``str``
+      # ! url -> the URL for the image
       table = "block"
       path = ["properties"]
       command = "update"
@@ -337,6 +347,9 @@ module Utils
     end
 
     def self.display_source(new_block_id, block_url)
+      # ! set the display source for the ImageBlock
+      # ! new_block_id -> the ID of the new ImageBlock: ``str``
+      # ! block_url -> the URL of the ImageBlock: ``str``
       {
         "id": new_block_id,
         "table": "block",
@@ -616,50 +629,7 @@ module Utils
       # ! payload for adding a column to the table.
       # ! collection_id -> the collection ID : ``str``
       # ! args -> the definition of the column : ``str``
-      args["format"] = {
-        "table_properties" => [
-          {
-            "property" => "title",
-            "visible" => true,
-            "width" => 280,
-          },
-          {
-            "property" => "aliases",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "category",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "description",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "ios_version",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "tags",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "phone",
-            "visible" => true,
-            "width" => 200,
-          },
-          {
-            "property" => "unicode_version",
-            "visible" => true,
-            "width" => 200,
-          },
-        ],
-      }
+
       {
         id: collection_id,
         table: "collection",

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -317,6 +317,38 @@ module Utils
         command: "set", "args": icon,
       }
     end
+    def self.source(new_block_id, url)
+      table = "block"
+      path = ["properties"]
+      command = "update"
+
+      {
+        id: new_block_id,
+        table: table,
+        path: path,
+        command: command,
+        args: {
+          source: [[
+            url,
+          ]],
+        },
+      }
+    end
+
+    def self.display_source(new_block_id, block_url)
+
+      {
+        "id": new_block_id,
+        "table": "block",
+        "path": [
+            "format"
+        ],
+        "command": "update",
+        "args": {
+            "display_source": block_url
+        }
+    }
+    end
   end
 
   class CollectionViewComponents

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -11,6 +11,27 @@ module Utils
   class BlockComponents
     # ! Each function defined here builds one component that is included in each request sent to Notions backend.
     # ! Each request sent will contain multiple components.
+    # TODO figure this out
+    def self.build_payload(operations, request_ids)
+      # ! properly formats the payload for Notions backend.
+      # ! operations -> an array of hashes that define the operations to perform : ``Array[Hash]``
+      # ! request_ids -> the unique IDs for the request : ``str``
+      request_id = request_ids[:request_id]
+      transaction_id = request_ids[:transaction_id]
+      space_id = request_ids[:space_id]
+      payload = {
+        requestId: request_id,
+        transactions: [
+          {
+            id: transaction_id,
+            shardId: 955_090,
+            spaceId: space_id,
+            operations: operations,
+          },
+        ],
+      }
+      payload
+    end
     def self.create(block_id, block_type)
       # ! payload for creating a block.
       # ! block_id -> id of the new block : ``str``
@@ -656,7 +677,7 @@ module Utils
     end
   end
 
-  def build_payload(operations, request_ids)
+  def self.build_payload(operations, request_ids)
     # ! properly formats the payload for Notions backend.
     # ! operations -> an array of hashes that define the operations to perform : ``Array[Hash]``
     # ! request_ids -> the unique IDs for the request : ``str``

--- a/lib/notion_api/version.rb
+++ b/lib/notion_api/version.rb
@@ -1,3 +1,3 @@
 module NotionAPI
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
 end

--- a/spec/blocks_spec.rb
+++ b/spec/blocks_spec.rb
@@ -17,7 +17,7 @@ describe NotionAPI::BlockTemplate do
     describe "#convert" do
       it "should convert the block to a different type and return the new block." do
         @block = $Block_spec_page.get_block($Block_spec_convert_id)
-        filtered_classes = Classes.select { |cls| ![:CollectionView, :CollectionViewRow, :CollectionViewPage].include?(cls)}
+        filtered_classes = Classes.select { |cls| ![:CollectionView, :CollectionViewRow, :CollectionViewPage, :ImageBlock].include?(cls)}
 
         number_of_classes = filtered_classes.length
         class_for_conversion = filtered_classes[rand(0...number_of_classes)]


### PR DESCRIPTION
- the create method is refactored to meet the requirements of polymorphism (method overriding). Now, certain blocks have separate `create` methods that override the default `BlockTemplate` self.create method.
- lots of refactoring to clean up code and remove unnecessary fluff
- ImageBlock is assigned its own `create` method which accepts an `options` keyword argument. The options keyword argument should be passed an image bey which defines the URL of the image to be created in Notion.
next step: allow file path to be specified for Notion ImageBlock