### PR TITLE
Add LinkBlock Support

### DIFF
--- a/lib/notion_api/blocks.rb
+++ b/lib/notion_api/blocks.rb
@@ -17,6 +17,7 @@ require_relative "notion_types/table_of_contents_block"
 require_relative "notion_types/text_block"
 require_relative "notion_types/todo_block"
 require_relative "notion_types/toggle_block"
+require_relative "notion_types/link_block"
 
 Classes = NotionAPI.constants.select { |c| NotionAPI.const_get(c).is_a? Class and c.to_s != 'BlockTemplate' and c.to_s != 'Core' and c.to_s !='Client' }
 notion_types = []

--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -72,6 +72,35 @@ module NotionAPI
       jsonified_record_response["block"][clean_id]["value"]["content"] || []
     end
 
+    def extract_id(url_or_id)
+      # ! parse and clean the URL or ID object provided.
+      # ! url_or_id -> the block ID or URL : ``str``
+      http_or_https = url_or_id.match(/^(http|https)/) # true if http or https in url_or_id...
+      collection_view_match = url_or_id.match(/(\?v=)/)
+
+      if (url_or_id.length == 36) && ((url_or_id.split("-").length == 5) && !http_or_https)
+        # passes if url_or_id is perfectly formatted already...
+        url_or_id
+      elsif (http_or_https && (url_or_id.split("-").last.length == 32)) || (!http_or_https && (url_or_id.length == 32)) || (collection_view_match)
+        # passes if either:
+        # 1. a URL is passed as url_or_id and the ID at the end is 32 characters long or
+        # 2. a URL is not passed and the ID length is 32 [aka unformatted]
+        pattern = [8, 13, 18, 23]
+        if collection_view_match
+          id_without_view = url_or_id.split("?")[0]
+          clean_id = id_without_view.split("/").last
+          pattern.each { |index| clean_id.insert(index, "-") }
+          clean_id
+        else
+          id = url_or_id.split("-").last
+          pattern.each { |index| id.insert(index, "-") }
+          id
+        end
+      else
+        raise ArgumentError, "Expected a Notion page URL or a page ID. Please consult the documentation for further information."
+      end
+    end
+
     private
 
     def get_notion_id(body)
@@ -205,34 +234,34 @@ module NotionAPI
       jsonified_record_response["block"][clean_id]["value"]["view_ids"] || []
     end
 
-    def extract_id(url_or_id)
-      # ! parse and clean the URL or ID object provided.
-      # ! url_or_id -> the block ID or URL : ``str``
-      http_or_https = url_or_id.match(/^(http|https)/) # true if http or https in url_or_id...
-      collection_view_match = url_or_id.match(/(\?v=)/)
+    # def extract_id(url_or_id)
+    #   # ! parse and clean the URL or ID object provided.
+    #   # ! url_or_id -> the block ID or URL : ``str``
+    #   http_or_https = url_or_id.match(/^(http|https)/) # true if http or https in url_or_id...
+    #   collection_view_match = url_or_id.match(/(\?v=)/)
 
-      if (url_or_id.length == 36) && ((url_or_id.split("-").length == 5) && !http_or_https)
-        # passes if url_or_id is perfectly formatted already...
-        url_or_id
-      elsif (http_or_https && (url_or_id.split("-").last.length == 32)) || (!http_or_https && (url_or_id.length == 32)) || (collection_view_match)
-        # passes if either:
-        # 1. a URL is passed as url_or_id and the ID at the end is 32 characters long or
-        # 2. a URL is not passed and the ID length is 32 [aka unformatted]
-        pattern = [8, 13, 18, 23]
-        if collection_view_match
-          id_without_view = url_or_id.split("?")[0]
-          clean_id = id_without_view.split("/").last
-          pattern.each { |index| clean_id.insert(index, "-") }
-          clean_id
-        else
-          id = url_or_id.split("-").last
-          pattern.each { |index| id.insert(index, "-") }
-          id
-        end
-      else
-        raise ArgumentError, "Expected a Notion page URL or a page ID. Please consult the documentation for further information."
-      end
-    end
+    #   if (url_or_id.length == 36) && ((url_or_id.split("-").length == 5) && !http_or_https)
+    #     # passes if url_or_id is perfectly formatted already...
+    #     url_or_id
+    #   elsif (http_or_https && (url_or_id.split("-").last.length == 32)) || (!http_or_https && (url_or_id.length == 32)) || (collection_view_match)
+    #     # passes if either:
+    #     # 1. a URL is passed as url_or_id and the ID at the end is 32 characters long or
+    #     # 2. a URL is not passed and the ID length is 32 [aka unformatted]
+    #     pattern = [8, 13, 18, 23]
+    #     if collection_view_match
+    #       id_without_view = url_or_id.split("?")[0]
+    #       clean_id = id_without_view.split("/").last
+    #       pattern.each { |index| clean_id.insert(index, "-") }
+    #       clean_id
+    #     else
+    #       id = url_or_id.split("-").last
+    #       pattern.each { |index| id.insert(index, "-") }
+    #       id
+    #     end
+    #   else
+    #     raise ArgumentError, "Expected a Notion page URL or a page ID. Please consult the documentation for further information."
+    #   end
+    # end
 
     def extract_collection_schema(collection_id, view_id, response = {})
       # ! retrieve the collection scehma. Useful for 'building' the backbone for a table.

--- a/lib/notion_api/notion_types/link_block.rb
+++ b/lib/notion_api/notion_types/link_block.rb
@@ -1,0 +1,51 @@
+module NotionAPI
+
+    # simiilar to code block but for mathematical functions.
+    class LinkBlock < BlockTemplate
+      @notion_type = "link_to_page"
+      @type = "link_to_page"
+  
+      def type
+        NotionAPI::LinkBlock.notion_type
+      end
+  
+      class << self
+        attr_reader :notion_type, :type
+      end
+
+      def self.create(block_id, new_block_id, block_title, target, position_command, request_ids, options)
+        block_title = super.extract_id(block_title)
+
+        cookies = Core.options["cookies"]
+        headers = Core.options["headers"]
+  
+        create_block_hash = Utils::BlockComponents.create(new_block_id, self.notion_type)
+        block_location_hash = Utils::BlockComponents.block_location_add(block_id, block_id, block_title, new_block_id, position_command)
+        last_edited_time_hash = Utils::BlockComponents.last_edited_time(block_id)
+        remove_item_hash = Utils::BlockComponents.block_location_remove( super.parent_id, new_block_id)
+  
+        operations = [
+          create_block_hash,
+          block_location_hash,
+          last_edited_time_hash,
+          remove_item_hash
+        ]
+  
+        request_url = URLS[:UPDATE_BLOCK]
+        request_body = Utils::BlockComponents.build_payload(operations, request_ids)
+        
+        response = HTTParty.post(
+          request_url,
+          body: request_body.to_json,
+          cookies: cookies,
+          headers: headers,
+        )
+
+        unless response.code == 200; raise "There was an issue completing your request. Here is the response from Notion: #{response.body}, and here is the payload that was sent: #{operations}.
+             Please try again, and if issues persist open an issue in GitHub.";       end
+  
+        self.new(new_block_id, block_title, block_id)
+      end
+    end
+  end
+  

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -11,7 +11,7 @@ module Utils
   class BlockComponents
     # ! Each function defined here builds one component that is included in each request sent to Notions backend.
     # ! Each request sent will contain multiple components.
-    # TODO figure this out
+
     def self.build_payload(operations, request_ids)
       # ! properly formats the payload for Notions backend.
       # ! operations -> an array of hashes that define the operations to perform : ``Array[Hash]``
@@ -351,14 +351,14 @@ module Utils
       # ! new_block_id -> the ID of the new ImageBlock: ``str``
       # ! block_url -> the URL of the ImageBlock: ``str``
       {
-        "id": new_block_id,
-        "table": "block",
-        "path": [
+        id: new_block_id,
+        table: "block",
+        path: [
           "format",
         ],
-        "command": "update",
-        "args": {
-          "display_source": block_url,
+        command: "update",
+        args: {
+          display_source: block_url,
         },
       }
     end

--- a/lib/notion_api/version.rb
+++ b/lib/notion_api/version.rb
@@ -1,3 +1,3 @@
 module NotionAPI
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
 end

--- a/spec/blocks_spec.rb
+++ b/spec/blocks_spec.rb
@@ -17,7 +17,7 @@ describe NotionAPI::BlockTemplate do
     describe "#convert" do
       it "should convert the block to a different type and return the new block." do
         @block = $Block_spec_page.get_block($Block_spec_convert_id)
-        filtered_classes = Classes.select { |cls| ![:CollectionView, :CollectionViewRow, :CollectionViewPage, :ImageBlock].include?(cls)}
+        filtered_classes = Classes.select { |cls| ![:CollectionView, :CollectionViewRow, :CollectionViewPage, :ImageBlock, :LinkBlock].include?(cls)}
 
         number_of_classes = filtered_classes.length
         class_for_conversion = filtered_classes[rand(0...number_of_classes)]


### PR DESCRIPTION
See #31.

Now, a `LinkBlock` can be created using:

```ruby
@client = NotionAPI::Client.new(ENV["token_v2"]
@page = @client.get_page("Page URL")
@page.create(NotionAPI::LinkBlock, "URL Of Page to Link")
```

For example:
```ruby
@client = NotionAPI::Client.new(ENV["token_v2"])
@page = @client.get_page("https://www.notion.so/danmurphy/Testing-227581d35fc94fa1a5f9fda1e8478d1e")
@page.create(NotionAPI::LinkBlock, "ea93213d1f21439c870fbe91503e76fe")
```

This creates a link for the page with ID `ea93213d1f21439c870fbe91503e76fe` on the `Testing` page.