### PR TITLE
Add content option to page block creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ If you want to create a new block whose parent ID is the **page**, call the `cre
 >>> @page.create(NotionAPI::TextBlock, "Hiya!", "ee0a6531-44cd-439f-a68c-1bdccbebfc8a", "before")
 #<NotionAPI::TextBlock:0x00007fecd8859880 **omitted**>
 ```
+4. `@page.create(<type_of_block>, "title of block", options: { content: "text or markdown" })` → create a new block with text or markdown content.
+```ruby
+>>> @page = @client.get_page("https://www.notion.so/danmurphy/Notion-API-Testing-66447bc817f044bc81ed3cf4802e9b00")
+>>> @page.create(NotionAPI::PageBlock, "Hiya!", options: { content: "# Yippee Ki Yay\n\nJohn McClane" })
+#<NotionAPI::PageBlock:0x00007fa77a1d0ca8 **omitted**>
+```
 ### Create a block whose parent is another block
 If you want to create a nested block whose parent ID is **another block**, call the `create` method on that block.
 1. `@block.create("<type_of_block", "title of block")` → create a new nested block whose parent ID is @block.id

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -119,5 +119,72 @@ module NotionAPI
 
       CollectionView.new(new_block_id, collection_title, parent_id, collection_id, view_id)
     end
+
+    def create(block_type, block_title, target = nil, position = "after", options: {})
+      page_block = super
+
+      if options[:content]
+        page_id = page_block.id
+        import_content_on_page(page_id, block_title, options[:content])
+      end
+
+      page_block
+    end
+
+    def import_content_on_page(page_id, block_title, content)
+      file_name      = "#{block_title}.md"
+      file_urls      = build_upload_file_urls(file_name)
+      signed_put_url = file_urls["signedPutUrl"]
+      file_url       = file_urls["url"]
+      unless signed_put_url && file_url; raise "Error on getting temporary file url uploaded."; end
+
+      upload_content_on_file(signed_put_url, content)
+      move_content_on_page(file_url, page_id, file_name)
+    end
+
+    def build_upload_file_urls(file_name)
+      request_body = {
+        bucket:      'temporary',
+        name:        file_name,
+        contentType: 'text/markdown'
+      }
+
+      HTTParty.post(
+        URLS[:GET_UPLOAD_FILE_URL],
+        body:    request_body.to_json,
+        cookies: Core.options["cookies"],
+        headers: Core.options["headers"]
+      )
+    end
+
+    def upload_content_on_file(signed_put_url, content)
+      HTTParty.put(
+        signed_put_url,
+        body:    content,
+        cookies: Core.options["cookies"],
+        headers: { "Content-Type" => "text/markdown" }
+      )
+    end
+
+    def move_content_on_page(file_url, page_id, file_name)
+      request_body = {
+        task: {
+          eventName: 'importFile',
+          request:   {
+            fileURL:    file_url,
+            fileName:   file_name,
+            importType: 'ReplaceBlock',
+            pageId:     page_id,
+          }
+        }
+      }
+
+      HTTParty.post(
+        URLS[:ENQUEUE_TASK],
+        body:    request_body.to_json,
+        cookies: Core.options["cookies"],
+        headers: Core.options["headers"]
+      )
+    end
   end
 end

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -136,7 +136,7 @@ module NotionAPI
       file_urls = build_upload_file_urls(file_name)
       signed_put_url = file_urls['signedPutUrl']
       file_url = file_urls['url']
-      unless signed_put_url && file_url; raise 'Error on getting temporary file url uploaded.'; end
+      if signed_put_url.nil? || file_url.nil?; raise 'Error on getting temporary file url uploaded.'; end
 
       upload_content_on_file(signed_put_url, content)
       move_content_on_page(file_url, page_id, file_name)
@@ -174,7 +174,7 @@ module NotionAPI
             fileURL: file_url,
             fileName: file_name,
             importType: 'ReplaceBlock',
-            pageId: page_id,
+            pageId: page_id
           }
         }
       }

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -123,23 +123,20 @@ module NotionAPI
     def create(block_type, block_title, target = nil, position = 'after', options: {})
       page_block = super
 
-      if options[:content]
-        page_id = page_block.id
-        import_content_on_page(page_id, block_title, options[:content])
-      end
+      page_block.import_content(options[:content]) if options[:content]
 
       page_block
     end
 
-    def import_content_on_page(page_id, block_title, content)
-      file_name = "#{block_title}.md"
+    def import_content(content)
+      file_name = "#{@title}.md"
       file_urls = build_upload_file_urls(file_name)
       signed_put_url = file_urls['signedPutUrl']
       file_url = file_urls['url']
       raise 'Error on getting temporary file url uploaded.' unless signed_put_url && file_url
 
       upload_content_on_file(signed_put_url, content)
-      move_content_on_page(file_url, page_id, file_name)
+      move_content_on_page(file_url, file_name)
     end
 
     def build_upload_file_urls(file_name)
@@ -166,7 +163,7 @@ module NotionAPI
       )
     end
 
-    def move_content_on_page(file_url, page_id, file_name)
+    def move_content_on_page(file_url, file_name)
       request_body = {
         task: {
           eventName: 'importFile',
@@ -174,7 +171,7 @@ module NotionAPI
             fileURL: file_url,
             fileName: file_name,
             importType: 'ReplaceBlock',
-            pageId: page_id
+            pageId: @id
           }
         }
       }

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -136,7 +136,7 @@ module NotionAPI
       file_urls = build_upload_file_urls(file_name)
       signed_put_url = file_urls['signedPutUrl']
       file_url = file_urls['url']
-      if signed_put_url.nil? || file_url.nil?; raise 'Error on getting temporary file url uploaded.'; end
+      raise 'Error on getting temporary file url uploaded.' unless signed_put_url && file_url
 
       upload_content_on_file(signed_put_url, content)
       move_content_on_page(file_url, page_id, file_name)

--- a/lib/notion_api/notion_types/page_block.rb
+++ b/lib/notion_api/notion_types/page_block.rb
@@ -120,7 +120,7 @@ module NotionAPI
       CollectionView.new(new_block_id, collection_title, parent_id, collection_id, view_id)
     end
 
-    def create(block_type, block_title, target = nil, position = "after", options: {})
+    def create(block_type, block_title, target = nil, position = 'after', options: {})
       page_block = super
 
       if options[:content]
@@ -132,11 +132,11 @@ module NotionAPI
     end
 
     def import_content_on_page(page_id, block_title, content)
-      file_name      = "#{block_title}.md"
-      file_urls      = build_upload_file_urls(file_name)
-      signed_put_url = file_urls["signedPutUrl"]
-      file_url       = file_urls["url"]
-      unless signed_put_url && file_url; raise "Error on getting temporary file url uploaded."; end
+      file_name = "#{block_title}.md"
+      file_urls = build_upload_file_urls(file_name)
+      signed_put_url = file_urls['signedPutUrl']
+      file_url = file_urls['url']
+      unless signed_put_url && file_url; raise 'Error on getting temporary file url uploaded.'; end
 
       upload_content_on_file(signed_put_url, content)
       move_content_on_page(file_url, page_id, file_name)
@@ -144,25 +144,25 @@ module NotionAPI
 
     def build_upload_file_urls(file_name)
       request_body = {
-        bucket:      'temporary',
-        name:        file_name,
+        bucket: 'temporary',
+        name: file_name,
         contentType: 'text/markdown'
       }
 
       HTTParty.post(
         URLS[:GET_UPLOAD_FILE_URL],
-        body:    request_body.to_json,
-        cookies: Core.options["cookies"],
-        headers: Core.options["headers"]
+        body: request_body.to_json,
+        cookies: Core.options['cookies'],
+        headers: Core.options['headers']
       )
     end
 
     def upload_content_on_file(signed_put_url, content)
       HTTParty.put(
         signed_put_url,
-        body:    content,
-        cookies: Core.options["cookies"],
-        headers: { "Content-Type" => "text/markdown" }
+        body: content,
+        cookies: Core.options['cookies'],
+        headers: { 'Content-Type' => 'text/markdown' }
       )
     end
 
@@ -170,20 +170,20 @@ module NotionAPI
       request_body = {
         task: {
           eventName: 'importFile',
-          request:   {
-            fileURL:    file_url,
-            fileName:   file_name,
+          request: {
+            fileURL: file_url,
+            fileName: file_name,
             importType: 'ReplaceBlock',
-            pageId:     page_id,
+            pageId: page_id,
           }
         }
       }
 
       HTTParty.post(
         URLS[:ENQUEUE_TASK],
-        body:    request_body.to_json,
-        cookies: Core.options["cookies"],
-        headers: Core.options["headers"]
+        body: request_body.to_json,
+        cookies: Core.options['cookies'],
+        headers: Core.options['headers']
       )
     end
   end

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -6,6 +6,8 @@ module Utils
     GET_BLOCK: "https://www.notion.so/api/v3/loadPageChunk",
     UPDATE_BLOCK: "https://www.notion.so/api/v3/saveTransactions",
     GET_COLLECTION: "https://www.notion.so/api/v3/queryCollection",
+    GET_UPLOAD_FILE_URL: "https://www.notion.so/api/v3/getUploadFileUrl",
+    ENQUEUE_TASK: "https://www.notion.so/api/v3/enqueueTask"
   }.freeze
 
   class BlockComponents

--- a/lib/notion_api/utils.rb
+++ b/lib/notion_api/utils.rb
@@ -6,8 +6,8 @@ module Utils
     GET_BLOCK: "https://www.notion.so/api/v3/loadPageChunk",
     UPDATE_BLOCK: "https://www.notion.so/api/v3/saveTransactions",
     GET_COLLECTION: "https://www.notion.so/api/v3/queryCollection",
-    GET_UPLOAD_FILE_URL: "https://www.notion.so/api/v3/getUploadFileUrl",
-    ENQUEUE_TASK: "https://www.notion.so/api/v3/enqueueTask"
+    GET_UPLOAD_FILE_URL: 'https://www.notion.so/api/v3/getUploadFileUrl',
+    ENQUEUE_TASK: 'https://www.notion.so/api/v3/enqueueTask'
   }.freeze
 
   class BlockComponents


### PR DESCRIPTION
I create PageBlock#create method that add the possibility to put some markdown content after the page creation.
I used the options hash of BlockTemplate#create to do so.

To import markdown content, there is 3 steps :
1. get upload file urls
2. upload content in the signed put url given
3. move content on the page created.

I took inspiration on this repo : https://github.com/webclipper/web-clipper/blob/eebc4a2ecf34fda83d5c32620fd68b1c52412f70/src/common/backend/services/notion/service.ts