### PR TITLE
Use 'title' to retrieve title instead of first key

### DIFF
--- a/lib/notion_api/core.rb
+++ b/lib/notion_api/core.rb
@@ -191,8 +191,8 @@ module NotionAPI
       else
         # titles for images are called source, while titles for text-based blocks are called title, so lets dynamically grab it
         # https://stackoverflow.com/questions/23765996/get-all-keys-from-ruby-hash/23766007
-        title_value = filter_nil_blocks[clean_id]["value"]["properties"].keys[0]
-        Core.type_whitelist.include?(filter_nil_blocks[clean_id]["value"]["type"]) ? nil : jsonified_record_response["block"][clean_id]["value"]["properties"][title_value].flatten[0]
+        title_key = 'title'
+        Core.type_whitelist.include?(filter_nil_blocks[clean_id]["value"]["type"]) ? nil : jsonified_record_response["block"][clean_id]["value"]["properties"][title_key].flatten[0]
       end
     end
 


### PR DESCRIPTION
Using the first key as the title key from `properties` on pages that were created via template gets the template title instead of the page's title. Just use use `'title'` as the key instead